### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@
 A Model Context Protocol (MCP) server implementation that integrates with [Olostep](https://olostep.com) for web scraping, content extraction, and search capabilities.
 To set up Olostep MCP Server, you need to have an API key. You can get the API key by signing up on the [Olostep website](https://olostep.com/auth).
 
+<a href="https://glama.ai/mcp/servers/@olostep/olostep-mcp-server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@olostep/olostep-mcp-server/badge" alt="olostep-mcp MCP server" />
+</a>
 
 ## Features
 


### PR DESCRIPTION
This PR adds a badge for the [olostep-mcp](https://glama.ai/mcp/servers/@olostep/olostep-mcp-server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@olostep/olostep-mcp-server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@olostep/olostep-mcp-server/badge" alt="olostep-mcp MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.