### PR TITLE
fix mcp http leak + sharpen tool descriptions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "olostep-mcp",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "olostep-mcp",
-      "version": "1.0.13",
+      "version": "1.0.14",
       "license": "ISC",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",
@@ -87,7 +87,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -596,7 +595,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -881,7 +879,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.8.tgz",
       "integrity": "sha512-VJCEvtrezO1IAR+kqEYnxUOoStaQPGrCmX3j4wDTNOcD1uRPFpGlwQUIW8niPuvHXaTUxeOUl5MMDGrl+tmO9A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "olostep-mcp",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "description": "API to search, extract and structure web data. Features web scraping, AI-powered answers with citations, batch processing (10k URLs), and autonomous site crawling for AI agents and LLMs.",
   "type": "module",
   "mcpName": "io.github.olostep/olostep-mcp-server",

--- a/src/index.ts
+++ b/src/index.ts
@@ -96,10 +96,11 @@ async function startHttp() {
             const server = createMcpServer(apiKey, orbitKey);
             const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
 
-            res.on("finish", () => {
+            res.on("close", () => {
                 const durationMs = Date.now() - start;
                 log("info", "Request handled", { durationMs, status: res.statusCode });
-                //server.close().catch(() => {});
+                transport.close().catch(() => {});
+                server.close().catch(() => {});
             });
 
             await server.connect(transport);

--- a/src/tools/batchScrapeUrls.ts
+++ b/src/tools/batchScrapeUrls.ts
@@ -50,7 +50,7 @@ export const batchScrapeUrls = {
 			.max(900)
 			.default(0)
 			.describe(
-				"Seconds to wait for batch completion. If >0, polls every 10s until done or timeout, then returns status. Use 0 to return immediately with batch_id (then call get_batch_results later). Recommended: 60 for small batches, 0 for large ones.",
+				"Seconds to wait for batch completion. If >0, polls every 10s until done or timeout, then returns status. Use 0 to return immediately with batch_id (then call get_batch_results later). Recommended: 60 for batches <50 URLs, 300–600 for 50–1k URLs, 0 for larger batches (poll separately).",
 			),
 	},
 	handler: async (

--- a/src/tools/createMap.ts
+++ b/src/tools/createMap.ts
@@ -19,9 +19,9 @@ export interface OlostepCreateMapResponse {
 export const createMap = {
 	name: "create_map",
 	description:
-    "Get a LIST of URLs on a website (URL discovery only - does NOT scrape content). " +
-    "Use this only when the user explicitly wants a *list of links* (e.g., 'show me all URLs on this site', 'map this website'). " +
-    "**Do NOT use this as a precursor to scraping** - if the user wants to scrape/crawl a site, use `create_crawl` directly (it discovers AND scrapes in one workflow).",
+    "Get a LIST of URLs on a website (URL discovery only — does NOT scrape content). " +
+    "Use when the user wants a list of links: 'show me all URLs on this site', 'map this website', or when you want to surface candidate URLs to the user before scraping a subset. " +
+    "Prefer `create_crawl` if the goal is to scrape the whole site — it discovers AND scrapes in one workflow. Use this only when the URL list itself is the deliverable.",
 	schema: {
 		website_url: z.string().url().describe("Website URL to extract links from."),
 		search_query: z.string().optional().describe('Optional search query to filter URLs (e.g., "blog").'),


### PR DESCRIPTION
Followups on #9.

- `src/index.ts`: switch `res.on('finish')` → `res.on('close')` and properly release `transport` + `server`. Restores cleanup that #9 commented out, without dropping streamed responses mid-flight. Stops a per-request leak under load.
- `src/tools/createMap.ts`: soften the "do NOT use as a precursor" line so legit URL-then-pick flows aren't blocked. Still steers the model to `create_crawl` for whole-site scraping.
- `src/tools/batchScrapeUrls.ts`: update `wait_for_completion_seconds` guidance to match the new 900s ceiling.
- Bump to 1.0.14.