### PR TITLE
add contract checks, integration tests, e2e gate, and production canary

### DIFF
--- a/.github/workflows/deploy-aws.yml
+++ b/.github/workflows/deploy-aws.yml
@@ -10,6 +10,7 @@ on:
       - "Dockerfile.cloud"
       - ".dockerignore.cloud"
       - "deploy/task-definition.json"
+      - "tests/**"
       - ".github/workflows/deploy-aws.yml"
   workflow_dispatch:
 
@@ -17,13 +18,53 @@ concurrency:
   group: deploy-aws
   cancel-in-progress: false
 
-permissions:
-  id-token: write
-  contents: read
-
 jobs:
-  deploy:
+  # Deep real-API gate. Spins up the freshly-built server locally and runs the
+  # full e2e suite (every tool + batch/crawl polling + error handling) against
+  # it. If anything fails, `deploy` never runs — bad code cannot reach clients.
+  e2e-gate:
+    name: E2E gate (full real-API suite)
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: "lts/*"
+      - name: Install
+        run: npm ci
+      - name: Build
+        run: npm run build
+      - name: Start MCP server (HTTP mode)
+        run: |
+          TRANSPORT=http PORT=3000 node build/index.js &
+          echo "MCP_PID=$!" >> "$GITHUB_ENV"
+          for i in $(seq 1 30); do
+            if curl -sf http://localhost:3000/health > /dev/null; then
+              echo "server healthy after ${i}s"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "::error::server did not become healthy in 30s"
+          exit 1
+      - name: Full e2e suite
+        env:
+          OLOSTEP_API_KEY: ${{ secrets.OLOSTEP_TEST_API_KEY }}
+          MCP_URL: http://localhost:3000/mcp
+        run: npm run test:e2e
+      - name: Stop MCP server
+        if: always()
+        run: kill "$MCP_PID" 2>/dev/null || true
+
+  deploy:
+    name: Build & deploy to ECS
+    runs-on: ubuntu-latest
+    needs: e2e-gate # deploy is blocked unless the full e2e suite passed
+    permissions:
+      id-token: write
+      contents: read
     env:
       AWS_REGION: us-east-1
       ECR_REPO: olostep-mcp-server

--- a/.github/workflows/deploy-aws.yml
+++ b/.github/workflows/deploy-aws.yml
@@ -71,3 +71,13 @@ jobs:
           cluster: ${{ env.CLUSTER }}
           service: ${{ env.SERVICE }}
           wait-for-service-stability: true
+
+      - name: Setup Node for post-deploy smoke
+        uses: actions/setup-node@v5
+        with:
+          node-version: "lts/*"
+
+      - name: Post-deploy smoke (live remote MCP)
+        env:
+          OLOSTEP_TEST_API_KEY: ${{ secrets.OLOSTEP_TEST_API_KEY }}
+        run: node tests/smoke.mjs remote --url https://mcp.olostep.com/mcp

--- a/.github/workflows/deploy-aws.yml
+++ b/.github/workflows/deploy-aws.yml
@@ -72,12 +72,12 @@ jobs:
           service: ${{ env.SERVICE }}
           wait-for-service-stability: true
 
-      - name: Setup Node for post-deploy smoke
+      - name: Setup Node for production canary
         uses: actions/setup-node@v5
         with:
           node-version: "lts/*"
 
-      - name: Post-deploy smoke (live remote MCP)
+      - name: Production canary (live mcp.olostep.com)
         env:
           OLOSTEP_TEST_API_KEY: ${{ secrets.OLOSTEP_TEST_API_KEY }}
         run: node tests/smoke.mjs remote --url https://mcp.olostep.com/mcp

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -1,8 +1,19 @@
 name: PR Tests
 
+# DO NOT change this trigger to `pull_request_target`.
+# `pull_request_target` runs in the BASE repo's context with secrets exposed and
+# the workflow's GITHUB_TOKEN granted write scope. Combined with `actions/checkout`
+# of the PR head, that's the classic supply-chain exfiltration RCE. The current
+# `pull_request` trigger is what makes fork PRs safe to run automatically.
 on:
   pull_request:
     branches: [main]
+
+# Cancel any in-flight runs when a PR is rebased / force-pushed. Saves Olostep API
+# credits (one scrape per real-API run) and CI minutes on noisy PRs.
+concurrency:
+  group: pr-test-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 permissions:
   contents: read
@@ -22,6 +33,8 @@ jobs:
         run: npm run build
       - name: Stdio schema smoke
         run: node tests/smoke.mjs stdio --module ./build/index.js --no-real
+      - name: Description goldens
+        run: npm run test:descriptions
 
   real-api-smoke:
     name: Real-API smoke (stdio)

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -19,8 +19,8 @@ permissions:
   contents: read
 
 jobs:
-  schema-smoke:
-    name: Schema smoke (no API key)
+  contract-check:
+    name: Contract check (schema + goldens, no API key)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -31,19 +31,19 @@ jobs:
         run: npm ci
       - name: Build
         run: npm run build
-      - name: Stdio schema smoke
+      - name: Stdio contract check (schema invariants)
         run: node tests/smoke.mjs stdio --module ./build/index.js --no-real
       - name: Description goldens
         run: npm run test:descriptions
 
-  real-api-smoke:
-    name: Real-API smoke (stdio)
+  integration-test:
+    name: Integration test (real API, stdio)
     runs-on: ubuntu-latest
     # Secrets aren't exposed to PRs from forks (GitHub policy, prevents secret exfiltration).
-    # Fork PRs are covered by `schema-smoke`; a maintainer can promote them to real smoke
-    # by triggering the `Verify PR (manual)` workflow with the PR number.
+    # Fork PRs are covered by `contract-check`; a maintainer can promote them to a real
+    # integration run by triggering the `Verify PR (manual)` workflow with the PR number.
     if: github.event.pull_request.head.repo.full_name == github.repository
-    needs: schema-smoke
+    needs: contract-check
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v5
@@ -53,7 +53,7 @@ jobs:
         run: npm ci
       - name: Build
         run: npm run build
-      - name: Stdio real-API smoke
+      - name: Stdio integration test
         env:
           OLOSTEP_TEST_API_KEY: ${{ secrets.OLOSTEP_TEST_API_KEY }}
         run: node tests/smoke.mjs stdio --module ./build/index.js

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -1,0 +1,46 @@
+name: PR Tests
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  schema-smoke:
+    name: Schema smoke (no API key)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: "lts/*"
+      - name: Install
+        run: npm ci
+      - name: Build
+        run: npm run build
+      - name: Stdio schema smoke
+        run: node tests/smoke.mjs stdio --module ./build/index.js --no-real
+
+  real-api-smoke:
+    name: Real-API smoke (stdio)
+    runs-on: ubuntu-latest
+    # Secrets aren't exposed to PRs from forks (GitHub policy, prevents secret exfiltration).
+    # Fork PRs are covered by `schema-smoke`; a maintainer can promote them to real smoke
+    # by triggering the `Verify PR (manual)` workflow with the PR number.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    needs: schema-smoke
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: "lts/*"
+      - name: Install
+        run: npm ci
+      - name: Build
+        run: npm run build
+      - name: Stdio real-API smoke
+        env:
+          OLOSTEP_TEST_API_KEY: ${{ secrets.OLOSTEP_TEST_API_KEY }}
+        run: node tests/smoke.mjs stdio --module ./build/index.js

--- a/.github/workflows/verify-pr.yml
+++ b/.github/workflows/verify-pr.yml
@@ -1,0 +1,47 @@
+name: Verify PR (manual)
+
+# Maintainer-triggered real-API smoke test against a specific PR's head ref.
+# Use this for fork PRs (where automatic real-API smoke can't run because secrets
+# are not exposed to fork workflows for security reasons).
+#
+# SECURITY: This checks out untrusted PR code and runs it with secrets in env.
+# Only trigger this after manually reviewing the PR diff for anything that could
+# exfiltrate the API key (e.g. modifying tests/smoke.mjs or build scripts to phone
+# home). If the PR looks safe, click Run workflow → enter PR number.
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number to verify with real-API smoke"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  smoke:
+    name: Real-API smoke (PR #${{ inputs.pr_number }})
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v5
+        with:
+          ref: refs/pull/${{ inputs.pr_number }}/head
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: "lts/*"
+
+      - name: Install
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Stdio real-API smoke
+        env:
+          OLOSTEP_TEST_API_KEY: ${{ secrets.OLOSTEP_TEST_API_KEY }}
+        run: node tests/smoke.mjs stdio --module ./build/index.js

--- a/.github/workflows/verify-pr.yml
+++ b/.github/workflows/verify-pr.yml
@@ -4,10 +4,23 @@ name: Verify PR (manual)
 # Use this for fork PRs (where automatic real-API smoke can't run because secrets
 # are not exposed to fork workflows for security reasons).
 #
-# SECURITY: This checks out untrusted PR code and runs it with secrets in env.
-# Only trigger this after manually reviewing the PR diff for anything that could
-# exfiltrate the API key (e.g. modifying tests/smoke.mjs or build scripts to phone
-# home). If the PR looks safe, click Run workflow → enter PR number.
+# SECURITY MODEL:
+# This workflow checks out untrusted PR code and runs it with OLOSTEP_TEST_API_KEY
+# in env. To prevent accidental approval:
+#   1. The job uses the `prod-smoke` GitHub Environment (set up in repo settings →
+#      Environments → prod-smoke → "Required reviewers: ZeeshanAdilButt").
+#      The secret is ONLY materialized after the reviewer clicks "Approve and
+#      deploy" on the pending workflow run. Triggering the workflow alone does
+#      not expose the secret.
+#   2. The job also runs `npm ci --ignore-scripts` so a malicious postinstall
+#      hook in a fork PR's package.json cannot run with the secret in env.
+#
+# Before approving the run, review the PR diff for:
+#   - changes to tests/, package.json scripts (build/prepare/postinstall), or
+#     .github/workflows/
+#   - new dependencies (they could exfiltrate the key during `npm run build`)
+#   - any imports of `process.env` or `child_process` in unexpected places
+# If the PR only touches src/ and a maintainer reviewed it, it's safe to approve.
 
 on:
   workflow_dispatch:
@@ -25,6 +38,7 @@ jobs:
   smoke:
     name: Real-API smoke (PR #${{ inputs.pr_number }})
     runs-on: ubuntu-latest
+    environment: prod-smoke # required reviewer gate — secret only injected after approval
     steps:
       - name: Checkout PR head
         uses: actions/checkout@v5
@@ -35,8 +49,8 @@ jobs:
         with:
           node-version: "lts/*"
 
-      - name: Install
-        run: npm ci
+      - name: Install (no scripts — neutralizes malicious postinstall in fork PRs)
+        run: npm ci --ignore-scripts
 
       - name: Build
         run: npm run build

--- a/.github/workflows/verify-pr.yml
+++ b/.github/workflows/verify-pr.yml
@@ -35,8 +35,8 @@ permissions:
   pull-requests: read
 
 jobs:
-  smoke:
-    name: Real-API smoke (PR #${{ inputs.pr_number }})
+  integration-verify:
+    name: Integration verify (PR #${{ inputs.pr_number }})
     runs-on: ubuntu-latest
     environment: prod-smoke # required reviewer gate — secret only injected after approval
     steps:
@@ -55,7 +55,7 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: Stdio real-API smoke
+      - name: Stdio integration test
         env:
           OLOSTEP_TEST_API_KEY: ${{ secrets.OLOSTEP_TEST_API_KEY }}
         run: node tests/smoke.mjs stdio --module ./build/index.js

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "build": "tsc && node -e \"const fs=require('fs');const p='build/index.js';let s=fs.readFileSync(p,'utf8');if(!s.startsWith('#!/usr/bin/env node')){fs.writeFileSync(p,'#!/usr/bin/env node\\n'+s);}fs.chmodSync(p,0o755);\"",
     "prepack": "npm run build",
     "prepublishOnly": "npm run build",
-    "validate-server-json": "node scripts/validate-schema.mjs"
+    "validate-server-json": "node scripts/validate-schema.mjs",
+    "test:descriptions": "node tests/check-descriptions.mjs"
   },
   "files": [
     "build/**/*"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "prepack": "npm run build",
     "prepublishOnly": "npm run build",
     "validate-server-json": "node scripts/validate-schema.mjs",
-    "test:descriptions": "node tests/check-descriptions.mjs"
+    "test:descriptions": "node tests/check-descriptions.mjs",
+    "test:e2e": "node tests/e2e.mjs"
   },
   "files": [
     "build/**/*"

--- a/tests/check-descriptions.mjs
+++ b/tests/check-descriptions.mjs
@@ -1,0 +1,136 @@
+#!/usr/bin/env node
+// Description goldens check.
+//
+// Compares the live `tools/list` output of the built MCP server to the checked-in
+// `tests/description-goldens.json`. If anything has drifted, the script fails with
+// a diff. To intentionally update the goldens (e.g. you reworded a tool description
+// in this PR), re-run with UPDATE_GOLDENS=1:
+//
+//   npm run test:descriptions              # checks
+//   UPDATE_GOLDENS=1 npm run test:descriptions  # writes
+//
+// The point of this is to make wording changes explicit: they show up as a diff
+// in the goldens file, in the same PR that changed the wording.
+
+import { spawn } from "node:child_process";
+import { readFileSync, writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import process from "node:process";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const goldensPath = join(__dirname, "description-goldens.json");
+const modulePath = join(__dirname, "..", "build", "index.js");
+
+async function getTools() {
+  const proc = spawn(process.execPath, [modulePath], {
+    env: { ...process.env, OLOSTEP_API_KEY: "fake-key-for-schema" },
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+  proc.stdout.setEncoding("utf8");
+  proc.stderr.on("data", () => {});
+
+  const pending = new Map();
+  let nextId = 1;
+  let buf = "";
+
+  proc.stdout.on("data", (chunk) => {
+    buf += chunk;
+    let nl;
+    while ((nl = buf.indexOf("\n")) !== -1) {
+      const line = buf.slice(0, nl).trim();
+      buf = buf.slice(nl + 1);
+      if (!line) continue;
+      try {
+        const msg = JSON.parse(line);
+        if (msg.id !== undefined && pending.has(msg.id)) {
+          const cb = pending.get(msg.id);
+          pending.delete(msg.id);
+          cb(msg);
+        }
+      } catch {
+        // ignore non-JSON noise
+      }
+    }
+  });
+
+  const req = (method, params) =>
+    new Promise((resolve, reject) => {
+      const id = nextId++;
+      pending.set(id, (msg) =>
+        msg.error ? reject(new Error(msg.error.message || JSON.stringify(msg.error))) : resolve(msg.result),
+      );
+      proc.stdin.write(JSON.stringify({ jsonrpc: "2.0", id, method, params }) + "\n");
+      setTimeout(() => {
+        if (pending.has(id)) {
+          pending.delete(id);
+          reject(new Error(`timeout after 30s on ${method}`));
+        }
+      }, 30000);
+    });
+
+  try {
+    await req("initialize", {
+      protocolVersion: "2025-06-18",
+      capabilities: {},
+      clientInfo: { name: "goldens", version: "1" },
+    });
+    proc.stdin.write(JSON.stringify({ jsonrpc: "2.0", method: "notifications/initialized" }) + "\n");
+    const r = await req("tools/list", {});
+    return r.tools;
+  } finally {
+    proc.kill();
+  }
+}
+
+const tools = await getTools();
+const current = Object.fromEntries(
+  tools
+    .sort((a, b) => a.name.localeCompare(b.name))
+    .map((t) => [t.name, { description: t.description || "" }]),
+);
+
+const payload = { version: 1, tools: current };
+
+if (process.env.UPDATE_GOLDENS === "1") {
+  writeFileSync(goldensPath, JSON.stringify(payload, null, 2) + "\n");
+  console.log(`Updated ${goldensPath} with ${tools.length} tool descriptions.`);
+  process.exit(0);
+}
+
+let golden;
+try {
+  golden = JSON.parse(readFileSync(goldensPath, "utf8"));
+} catch {
+  console.error(`error: missing or invalid ${goldensPath}. Run with UPDATE_GOLDENS=1 to create it.`);
+  process.exit(2);
+}
+
+const diffs = [];
+const goldenTools = golden.tools || {};
+for (const name of Object.keys(current)) {
+  const g = goldenTools[name];
+  if (!g) {
+    diffs.push(`new tool not in goldens: ${name}\n    description: ${current[name].description}`);
+    continue;
+  }
+  if (g.description !== current[name].description) {
+    diffs.push(
+      `description changed for ${name}:\n  -- golden: ${JSON.stringify(g.description)}\n  ++ live:   ${JSON.stringify(current[name].description)}`,
+    );
+  }
+}
+for (const name of Object.keys(goldenTools)) {
+  if (!current[name]) diffs.push(`tool in goldens but not live: ${name}`);
+}
+
+if (diffs.length === 0) {
+  console.log(`OK — ${tools.length} tool descriptions match goldens.`);
+  process.exit(0);
+}
+
+console.log(`FAIL — ${diffs.length} description diff(s):\n`);
+for (const d of diffs) console.log(d + "\n");
+console.log("If the change is intentional, update goldens with:");
+console.log("  UPDATE_GOLDENS=1 node tests/check-descriptions.mjs");
+process.exit(1);

--- a/tests/description-goldens.json
+++ b/tests/description-goldens.json
@@ -1,0 +1,35 @@
+{
+  "version": 1,
+  "tools": {
+    "answers": {
+      "description": "Search the web and return AI-powered answers in the JSON structure you want, with sources and citations."
+    },
+    "batch_scrape_urls": {
+      "description": "Scrape a SPECIFIC, KNOWN list of URLs (typically from different domains). **Do NOT use this for crawling a website** - if the user wants to scrape a whole site or 'crawl' a domain, use `create_crawl` instead. Use this only when you already have an explicit list of URLs to scrape (e.g., user provides a CSV of URLs, or you need to scrape unrelated pages). Returns a batch_id immediately. Use `get_batch_results` with the batch_id to fetch the scraped content once the batch completes (~5–8 min). Set `wait_for_completion_seconds` to poll automatically."
+    },
+    "create_crawl": {
+      "description": "**PREFERRED tool for crawling a website.** Use this whenever the user says 'crawl', 'scrape the whole site', 'get all pages from a site', or wants multiple pages from a single domain. This is the CORRECT tool for any whole-site scraping task. **Do NOT use `batch_scrape_urls` for crawling** - that tool is only for when you already have a specific list of unrelated URLs from different domains. Starts an ASYNC crawl that autonomously discovers and scrapes pages by following links from a start URL. Returns a crawl_id - the crawl runs in the background. You MUST then call `get_crawl_results` with the returned crawl_id to poll status and retrieve the scraped pages. Do NOT call `get_batch_results` with a crawl_id - crawls and batches are separate resources."
+    },
+    "create_map": {
+      "description": "Get a LIST of URLs on a website (URL discovery only — does NOT scrape content). Use when the user wants a list of links: 'show me all URLs on this site', 'map this website', or when you want to surface candidate URLs to the user before scraping a subset. Prefer `create_crawl` if the goal is to scrape the whole site — it discovers AND scrapes in one workflow. Use this only when the URL list itself is the deliverable."
+    },
+    "get_batch_results": {
+      "description": "Retrieve the status and scraped content for a batch job. Pass the batch_id returned by batch_scrape_urls. If the batch is completed, returns the scraped content for each URL. If still in_progress, returns the current status so you can call again later."
+    },
+    "get_crawl_results": {
+      "description": "Retrieve the status and scraped pages for a crawl job. Pass the crawl_id returned by create_crawl. If the crawl is still in_progress, returns the current status so you can call again later (poll every ~10 seconds). Once completed, returns the list of discovered pages with their scraped content in the requested formats. This is the REQUIRED companion to create_crawl — create_crawl only kicks off the async job, this tool is how you actually get the content."
+    },
+    "get_webpage_content": {
+      "description": "Retrieve content of a webpage in markdown"
+    },
+    "get_website_urls": {
+      "description": "Search and retrieve relevant URLs from a website (URL discovery only - does NOT scrape content). Use this only when the user wants a *filtered list of links* matching a search query. **Do NOT use this as a precursor to scraping** - if the user wants to scrape/crawl a site, use `create_crawl` directly."
+    },
+    "scrape_website": {
+      "description": "Extract content from a single URL. Supports multiple formats and JavaScript rendering."
+    },
+    "search_web": {
+      "description": "Search the web for a given query and return structured results (non-AI, parser-based)."
+    }
+  }
+}

--- a/tests/e2e.mjs
+++ b/tests/e2e.mjs
@@ -1,0 +1,377 @@
+#!/usr/bin/env node
+/**
+ * Deep end-to-end test suite for the Olostep MCP server.
+ *
+ * Exercises every tool with real Olostep API calls, including the async
+ * batch and crawl polling workflows and error handling. Uses the official
+ * MCP SDK client over Streamable HTTP.
+ *
+ * Target is configurable so the same suite runs:
+ *   - in CI before deploy, against a locally-spawned server
+ *   - after deploy, against the live hosted server
+ *
+ * Env:
+ *   MCP_URL          MCP endpoint (default: https://mcp.olostep.com/mcp)
+ *   HEALTH_URL       health endpoint (default: derived from MCP_URL)
+ *   OLOSTEP_API_KEY  API key (falls back to OLOSTEP_TEST_API_KEY)
+ *
+ * Exit codes: 0 = all pass, 1 = any failure.
+ */
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+
+const MCP_URL = process.env.MCP_URL ?? "https://mcp.olostep.com/mcp";
+const API_KEY = process.env.OLOSTEP_API_KEY ?? process.env.OLOSTEP_TEST_API_KEY;
+const HEALTH_URL = process.env.HEALTH_URL ?? MCP_URL.replace(/\/mcp\/?$/, "/health");
+
+const EXPECTED_TOOLS = [
+  "create_map",
+  "create_crawl",
+  "get_crawl_results",
+  "batch_scrape_urls",
+  "get_batch_results",
+  "answers",
+  "search_web",
+  "scrape_website",
+  "get_webpage_content",
+  "get_website_urls",
+];
+
+const results = [];
+
+function log(status, name, detail = "") {
+  const row = { status, name, detail: String(detail).slice(0, 200) };
+  results.push(row);
+  const icon = status === "PASS" ? "✓" : status === "SKIP" ? "○" : "✗";
+  console.log(`${icon} ${status.padEnd(5)} ${name}${detail ? ` — ${detail}` : ""}`);
+}
+
+function parseToolText(result) {
+  const text = result?.content?.find((c) => c.type === "text")?.text ?? "";
+  try {
+    return JSON.parse(text);
+  } catch {
+    return { _raw: text };
+  }
+}
+
+function hasWebsiteUrls(data) {
+  if (Array.isArray(data.urls) && data.urls.length > 0) return true;
+  const raw = data._raw ?? "";
+  return /Found \d+ URLs/i.test(raw) || (raw.includes("https://") && raw.split("https://").length > 2);
+}
+
+async function call(client, name, args, timeoutMs = 300000) {
+  const controller = new AbortController();
+  const t = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await client.callTool({ name, arguments: args }, undefined, {
+      signal: controller.signal,
+    });
+  } finally {
+    clearTimeout(t);
+  }
+}
+
+function sleep(ms) {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+async function main() {
+  if (!API_KEY) {
+    console.error("OLOSTEP_API_KEY (or OLOSTEP_TEST_API_KEY) is not set");
+    process.exit(1);
+  }
+
+  console.log(`\n=== Olostep MCP E2E ===`);
+  console.log(`target: ${MCP_URL}\n`);
+
+  // 0. Health
+  try {
+    const h = await fetch(HEALTH_URL);
+    const body = await h.json();
+    log(h.ok && body.status === "ok" ? "PASS" : "FAIL", "health_endpoint", JSON.stringify(body));
+  } catch (e) {
+    log("FAIL", "health_endpoint", e.message);
+  }
+
+  const transport = new StreamableHTTPClientTransport(new URL(MCP_URL), {
+    requestInit: { headers: { Authorization: `Bearer ${API_KEY}` } },
+  });
+  const client = new Client({ name: "e2e-suite", version: "1.0.0" });
+
+  try {
+    await client.connect(transport);
+    log("PASS", "mcp_connect");
+  } catch (e) {
+    log("FAIL", "mcp_connect", e.message);
+    printSummary();
+    process.exit(1);
+  }
+
+  // 1. listTools
+  let tools;
+  try {
+    const listed = await client.listTools();
+    tools = listed.tools.map((t) => t.name).sort();
+    const missing = EXPECTED_TOOLS.filter((n) => !tools.includes(n));
+    const extra = tools.filter((n) => !EXPECTED_TOOLS.includes(n));
+    if (missing.length === 0 && tools.length >= 10) {
+      log("PASS", "list_tools", `${tools.length} tools`);
+    } else {
+      log("FAIL", "list_tools", `missing=${missing.join(",")} extra=${extra.join(",")}`);
+    }
+  } catch (e) {
+    log("FAIL", "list_tools", e.message);
+    await client.close();
+    printSummary();
+    process.exit(1);
+  }
+
+  // 2. scrape_website — markdown
+  try {
+    const r = await call(client, "scrape_website", {
+      url_to_scrape: "https://example.com",
+      output_format: "markdown",
+    });
+    const data = parseToolText(r);
+    const md = data.markdown_content ?? data.result?.markdown_content ?? "";
+    log(!r.isError && md.includes("Example Domain") ? "PASS" : "FAIL", "scrape_website_markdown");
+  } catch (e) {
+    log("FAIL", "scrape_website_markdown", e.message);
+  }
+
+  // 3. scrape_website — html
+  try {
+    const r = await call(client, "scrape_website", {
+      url_to_scrape: "https://example.com",
+      output_format: "html",
+      wait_before_scraping: 0,
+    });
+    const data = parseToolText(r);
+    const html = data.html_content ?? data.result?.html_content ?? "";
+    log(!r.isError && (html.includes("Example") || html.includes("example")) ? "PASS" : "FAIL", "scrape_website_html");
+  } catch (e) {
+    log("FAIL", "scrape_website_html", e.message);
+  }
+
+  // 4. get_webpage_content
+  try {
+    const r = await call(client, "get_webpage_content", {
+      url_to_scrape: "https://example.com",
+    });
+    const data = parseToolText(r);
+    const md = data.markdown_content ?? data.result?.markdown_content ?? data._raw ?? "";
+    log(!r.isError && String(md).includes("Example") ? "PASS" : "FAIL", "get_webpage_content");
+  } catch (e) {
+    log("FAIL", "get_webpage_content", e.message);
+  }
+
+  // 5. search_web
+  try {
+    const r = await call(client, "search_web", {
+      query: "Model Context Protocol MCP",
+      country: "US",
+    });
+    const data = parseToolText(r);
+    const hasOrganic = Array.isArray(data.organic) && data.organic.length > 0;
+    log(!r.isError && hasOrganic ? "PASS" : "FAIL", "search_web", hasOrganic ? `${data.organic.length} results` : "");
+  } catch (e) {
+    log("FAIL", "search_web", e.message);
+  }
+
+  // 6. answers
+  try {
+    const r = await call(client, "answers", {
+      task: "What is example.com used for? Answer in one short sentence.",
+    }, 180000);
+    const data = parseToolText(r);
+    const hasAnswer =
+      data.result?.json_content ||
+      data.json_content ||
+      (data._raw && data._raw.length > 20);
+    log(!r.isError && hasAnswer ? "PASS" : "FAIL", "answers");
+  } catch (e) {
+    log("FAIL", "answers", e.message);
+  }
+
+  // 7. create_map
+  let mapUrls = [];
+  try {
+    const r = await call(client, "create_map", {
+      website_url: "https://docs.olostep.com",
+      top_n: 5,
+    }, 180000);
+    const data = parseToolText(r);
+    mapUrls = data.urls ?? [];
+    log(!r.isError && mapUrls.length > 0 ? "PASS" : "FAIL", "create_map", `${mapUrls.length} urls`);
+  } catch (e) {
+    log("FAIL", "create_map", e.message);
+  }
+
+  // 8. get_website_urls (requires search_query)
+  try {
+    const r = await call(client, "get_website_urls", {
+      url: "https://docs.olostep.com",
+      search_query: "api",
+    }, 180000);
+    const data = parseToolText(r);
+    log(!r.isError && hasWebsiteUrls(data) ? "PASS" : "FAIL", "get_website_urls");
+  } catch (e) {
+    log("FAIL", "get_website_urls", e.message);
+  }
+
+  // 9. batch workflow
+  let batchId = null;
+  try {
+    const r = await call(client, "batch_scrape_urls", {
+      urls_to_scrape: [
+        { url: "https://example.com", custom_id: "0" },
+        { url: "https://iana.org/domains/example", custom_id: "1" },
+      ],
+      output_format: "markdown",
+      wait_for_completion_seconds: 0,
+    }, 90000);
+    const data = parseToolText(r);
+    batchId = data.id ?? data.batch_id ?? null;
+    const status = data.status ?? "";
+    const done = status === "completed" || (data.completed_urls >= 2);
+    log(!r.isError && batchId ? "PASS" : "FAIL", "batch_scrape_urls", `id=${batchId} status=${status}`);
+    if (!done && batchId) {
+      log("SKIP", "batch_wait_inline", "not completed inline, will poll");
+    }
+  } catch (e) {
+    log("FAIL", "batch_scrape_urls", e.message);
+  }
+
+  // 10. get_batch_results
+  if (batchId) {
+    try {
+      let completed = false;
+      for (let i = 0; i < 18 && !completed; i++) {
+        const r = await call(client, "get_batch_results", {
+          batch_id: batchId,
+          formats: ["markdown"],
+          items_limit: 5,
+        });
+        const data = parseToolText(r);
+        const status = data.status ?? "";
+        if (status === "completed" || (data.items && data.items.length > 0)) {
+          completed = true;
+          const count = data.items?.length ?? data.items_count ?? 0;
+          log(!r.isError ? "PASS" : "FAIL", "get_batch_results", `status=${status} items=${count}`);
+          break;
+        }
+        if (i < 17) await sleep(10000);
+      }
+      if (!completed) log("FAIL", "get_batch_results", "timeout after polling");
+    } catch (e) {
+      log("FAIL", "get_batch_results", e.message);
+    }
+  } else {
+    log("SKIP", "get_batch_results", "no batch_id");
+  }
+
+  // 11. crawl workflow
+  let crawlId = null;
+  try {
+    const r = await call(client, "create_crawl", {
+      start_url: "https://example.com",
+      max_pages: 2,
+      follow_links: true,
+      output_format: "markdown",
+    }, 120000);
+    const data = parseToolText(r);
+    crawlId = data.crawl_id ?? data.id ?? null;
+    log(!r.isError && crawlId ? "PASS" : "FAIL", "create_crawl", `id=${crawlId}`);
+  } catch (e) {
+    log("FAIL", "create_crawl", e.message);
+  }
+
+  // 12. get_crawl_results (poll)
+  if (crawlId) {
+    try {
+      let done = false;
+      for (let i = 0; i < 24 && !done; i++) {
+        const r = await call(client, "get_crawl_results", {
+          crawl_id: crawlId,
+          formats: ["markdown"],
+          items_limit: 5,
+        }, 120000);
+        const data = parseToolText(r);
+        const status = data.status ?? "";
+        const pages = data.pages ?? data.items ?? [];
+        if (status === "completed" || pages.length > 0) {
+          done = true;
+          log(!r.isError ? "PASS" : "FAIL", "get_crawl_results", `status=${status} pages=${pages.length}`);
+          break;
+        }
+        if (i < 23) await sleep(10000);
+      }
+      if (!done) log("FAIL", "get_crawl_results", "timeout after polling");
+    } catch (e) {
+      log("FAIL", "get_crawl_results", e.message);
+    }
+  } else {
+    log("SKIP", "get_crawl_results", "no crawl_id");
+  }
+
+  // 13. answers with JSON shape
+  try {
+    const r = await call(client, "answers", {
+      task: "What is the Model Context Protocol?",
+      json: { summary: "", official_url: "" },
+    }, 180000);
+    const data = parseToolText(r);
+    log(!r.isError && (data.result || data._raw?.length > 30) ? "PASS" : "FAIL", "answers_structured_json");
+  } catch (e) {
+    log("FAIL", "answers_structured_json", e.message);
+  }
+
+  // 14. scrape with country
+  try {
+    const r = await call(client, "scrape_website", {
+      url_to_scrape: "https://example.com",
+      output_format: "markdown",
+      country: "US",
+    });
+    const data = parseToolText(r);
+    const md = data.markdown_content ?? data.result?.markdown_content ?? "";
+    const ok = !r.isError && (String(md).includes("Example") || data.page_metadata?.status_code === 200);
+    log(ok ? "PASS" : "FAIL", "scrape_website_country_us");
+  } catch (e) {
+    log("FAIL", "scrape_website_country_us", e.message);
+  }
+
+  // 15. Error handling — invalid URL
+  try {
+    const r = await call(client, "scrape_website", {
+      url_to_scrape: "https://this-domain-definitely-does-not-exist-olostep-e2e.invalid",
+      output_format: "markdown",
+    }, 60000);
+    log(r.isError ? "PASS" : "FAIL", "error_invalid_domain", r.isError ? "returned isError" : "unexpected success");
+  } catch (e) {
+    log("PASS", "error_invalid_domain", "threw as expected");
+  }
+
+  await client.close();
+  printSummary();
+}
+
+function printSummary() {
+  const pass = results.filter((r) => r.status === "PASS").length;
+  const fail = results.filter((r) => r.status === "FAIL").length;
+  const skip = results.filter((r) => r.status === "SKIP").length;
+  console.log("\n=== Summary ===");
+  console.log(`PASS: ${pass}  FAIL: ${fail}  SKIP: ${skip}  TOTAL: ${results.length}`);
+  if (fail > 0) {
+    console.log("\nFailed:");
+    results.filter((r) => r.status === "FAIL").forEach((r) => console.log(`  - ${r.name}: ${r.detail}`));
+    process.exit(1);
+  }
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/tests/smoke.mjs
+++ b/tests/smoke.mjs
@@ -28,6 +28,7 @@ class StdioTransport {
       env: { ...process.env, OLOSTEP_API_KEY: this.apiKey },
       stdio: ["pipe", "pipe", "pipe"],
     });
+    this.proc.stdout.setEncoding("utf8"); // avoid utf-8 corruption across chunk boundaries
     this.proc.stderr.on("data", () => {}); // server logs go to stderr — ignore
     this.proc.on("error", (e) => {
       console.error("spawn failed:", e.message);
@@ -36,7 +37,7 @@ class StdioTransport {
 
     let buf = "";
     this.proc.stdout.on("data", (chunk) => {
-      buf += chunk.toString();
+      buf += chunk;
       let nl;
       while ((nl = buf.indexOf("\n")) !== -1) {
         const line = buf.slice(0, nl).trim();
@@ -57,7 +58,8 @@ class StdioTransport {
       }
     });
 
-    await new Promise((r) => setTimeout(r, 300)); // give server a tick to boot
+    // JSON-RPC over stdio is request/response — the per-request timeout in `request()`
+    // covers slow boot. No artificial sleep needed.
   }
 
   request(method, params) {
@@ -125,15 +127,22 @@ class RemoteTransport {
 // ---------- util ----------
 
 function parseSse(text) {
-  // Streamable HTTP: lines like "event: message\ndata: {json}\n\n"
+  // SSE per spec: events separated by blank lines; multiple `data:` lines per event
+  // are joined with `\n` before parsing. Today the server emits single-line JSON, but
+  // if it ever pretty-prints or chunks at a `\n` inside a string, the naive grep
+  // would drop the message.
   const out = [];
-  for (const line of text.split("\n")) {
-    if (line.startsWith("data: ")) {
-      try {
-        out.push(JSON.parse(line.slice(6)));
-      } catch {
-        // ignore non-JSON data lines
-      }
+  for (const event of text.split(/\r?\n\r?\n/)) {
+    const dataLines = [];
+    for (const line of event.split(/\r?\n/)) {
+      if (line.startsWith("data: ")) dataLines.push(line.slice(6));
+      else if (line.startsWith("data:")) dataLines.push(line.slice(5));
+    }
+    if (dataLines.length === 0) continue;
+    try {
+      out.push(JSON.parse(dataLines.join("\n")));
+    } catch {
+      // ignore non-JSON event
     }
   }
   return out;
@@ -213,24 +222,38 @@ async function main() {
     if (w?.maximum !== 900) throw new Error(`maximum = ${w?.maximum}, expected 900`);
   });
 
-  await check("schema: create_crawl description marked PREFERRED for crawling", () => {
-    const t = tools.find((x) => x.name === "create_crawl");
-    if (!t?.description?.includes("PREFERRED tool for crawling")) {
-      throw new Error("description missing 'PREFERRED tool for crawling'");
+  // Trip-wires: every tool has a meaningful description that mentions its core verb.
+  // Exact-wording assertions (e.g. "PREFERRED tool for crawling") live in the golden
+  // file at `tests/description-goldens.json` and are checked by
+  // `tests/check-descriptions.mjs`. That separate check fails loudly if descriptions
+  // drift without an intentional goldens update — but doesn't break this smoke on
+  // every wording tweak.
+  await check("schema: every tool has a non-trivial description", () => {
+    for (const t of tools) {
+      if (!t.description || t.description.length < 40) {
+        throw new Error(`tool ${t.name} has missing/short description (${t.description?.length || 0} chars)`);
+      }
     }
   });
 
-  await check("schema: batch_scrape_urls description steers away from crawling", () => {
-    const t = tools.find((x) => x.name === "batch_scrape_urls");
-    if (!t?.description?.includes("Do NOT use this for crawling")) {
-      throw new Error("description missing 'Do NOT use this for crawling'");
-    }
-  });
-
-  await check("schema: create_map description prefers create_crawl for whole-site", () => {
-    const t = tools.find((x) => x.name === "create_map");
-    if (!t?.description?.includes("Prefer `create_crawl`")) {
-      throw new Error("description missing 'Prefer `create_crawl`'");
+  await check("schema: expected tool set is present", () => {
+    const expected = [
+      "scrape_website",
+      "get_webpage_content",
+      "search_web",
+      "answers",
+      "batch_scrape_urls",
+      "get_batch_results",
+      "create_crawl",
+      "get_crawl_results",
+      "create_map",
+      "get_website_urls",
+    ];
+    const got = new Set(tools.map((t) => t.name));
+    const missing = expected.filter((n) => !got.has(n));
+    const unexpected = [...got].filter((n) => !expected.includes(n));
+    if (missing.length || unexpected.length) {
+      throw new Error(`missing=[${missing.join(",")}] unexpected=[${unexpected.join(",")}]`);
     }
   });
 

--- a/tests/smoke.mjs
+++ b/tests/smoke.mjs
@@ -1,0 +1,263 @@
+#!/usr/bin/env node
+// Universal MCP smoke test for the Olostep MCP server.
+//
+// Modes:
+//   node tests/smoke.mjs stdio  [--module ./build/index.js] [--no-real]
+//   node tests/smoke.mjs remote --url https://mcp.olostep.com/mcp  [--no-real]
+//
+// Reads the API key from OLOSTEP_TEST_API_KEY. If unset (or --no-real is passed),
+// the real-API check is skipped — schema/protocol checks still run.
+//
+// Exit codes: 0 = all checks pass, 1 = any check failed, 2 = bad args.
+
+import { spawn } from "node:child_process";
+import process from "node:process";
+
+// ---------- Transports ----------
+
+class StdioTransport {
+  constructor(modulePath, apiKey) {
+    this.modulePath = modulePath;
+    this.apiKey = apiKey;
+    this.pending = new Map();
+    this.nextId = 1;
+  }
+
+  async start() {
+    this.proc = spawn(process.execPath, [this.modulePath], {
+      env: { ...process.env, OLOSTEP_API_KEY: this.apiKey },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    this.proc.stderr.on("data", () => {}); // server logs go to stderr — ignore
+    this.proc.on("error", (e) => {
+      console.error("spawn failed:", e.message);
+      process.exit(1);
+    });
+
+    let buf = "";
+    this.proc.stdout.on("data", (chunk) => {
+      buf += chunk.toString();
+      let nl;
+      while ((nl = buf.indexOf("\n")) !== -1) {
+        const line = buf.slice(0, nl).trim();
+        buf = buf.slice(nl + 1);
+        if (!line) continue;
+        let msg;
+        try {
+          msg = JSON.parse(line);
+        } catch {
+          continue;
+        }
+        if (msg.id !== undefined && this.pending.has(msg.id)) {
+          const { resolve, reject } = this.pending.get(msg.id);
+          this.pending.delete(msg.id);
+          if (msg.error) reject(new Error(msg.error.message || JSON.stringify(msg.error)));
+          else resolve(msg.result);
+        }
+      }
+    });
+
+    await new Promise((r) => setTimeout(r, 300)); // give server a tick to boot
+  }
+
+  request(method, params) {
+    const id = this.nextId++;
+    return new Promise((resolve, reject) => {
+      this.pending.set(id, { resolve, reject });
+      this.proc.stdin.write(JSON.stringify({ jsonrpc: "2.0", id, method, params }) + "\n");
+      setTimeout(() => {
+        if (this.pending.has(id)) {
+          this.pending.delete(id);
+          reject(new Error(`timeout after 60s on ${method}`));
+        }
+      }, 60000);
+    });
+  }
+
+  notify(method, params) {
+    this.proc.stdin.write(JSON.stringify({ jsonrpc: "2.0", method, params }) + "\n");
+  }
+
+  async stop() {
+    this.proc?.kill();
+  }
+}
+
+class RemoteTransport {
+  constructor(url, apiKey) {
+    this.url = url;
+    this.apiKey = apiKey;
+    this.nextId = 1;
+  }
+
+  async start() {}
+
+  async request(method, params) {
+    const id = this.nextId++;
+    const res = await fetch(this.url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json, text/event-stream",
+        Authorization: `Bearer ${this.apiKey}`,
+      },
+      body: JSON.stringify({ jsonrpc: "2.0", id, method, params }),
+    });
+    if (!res.ok) {
+      const body = await res.text().catch(() => "");
+      throw new Error(`HTTP ${res.status} on ${method}: ${body.slice(0, 200)}`);
+    }
+    const text = await res.text();
+    const messages = parseSse(text);
+    const msg = messages.find((m) => m.id === id) || messages[0];
+    if (!msg) throw new Error(`empty response on ${method}: ${text.slice(0, 200)}`);
+    if (msg.error) throw new Error(msg.error.message || JSON.stringify(msg.error));
+    return msg.result;
+  }
+
+  notify() {
+    // stateless server has no persistent session — notifications are no-ops here
+  }
+
+  async stop() {}
+}
+
+// ---------- util ----------
+
+function parseSse(text) {
+  // Streamable HTTP: lines like "event: message\ndata: {json}\n\n"
+  const out = [];
+  for (const line of text.split("\n")) {
+    if (line.startsWith("data: ")) {
+      try {
+        out.push(JSON.parse(line.slice(6)));
+      } catch {
+        // ignore non-JSON data lines
+      }
+    }
+  }
+  return out;
+}
+
+function parseArgs(argv) {
+  const out = { mode: argv[0] };
+  for (let i = 1; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--no-real") out.noReal = true;
+    else if (a === "--module") out.module = argv[++i];
+    else if (a === "--url") out.url = argv[++i];
+  }
+  return out;
+}
+
+function die(msg) {
+  console.error(`error: ${msg}`);
+  process.exit(2);
+}
+
+// ---------- main ----------
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const apiKey = process.env.OLOSTEP_TEST_API_KEY || "";
+  const skipReal = args.noReal || !apiKey;
+
+  let transport;
+  if (args.mode === "stdio") {
+    transport = new StdioTransport(args.module || "./build/index.js", apiKey || "fake-key-for-schema");
+  } else if (args.mode === "remote") {
+    if (!args.url) die('--url is required for "remote" mode');
+    transport = new RemoteTransport(args.url, apiKey || "fake-key-for-schema");
+  } else {
+    die('mode must be "stdio" or "remote"');
+  }
+
+  const results = [];
+  const check = async (name, fn) => {
+    try {
+      await fn();
+      results.push({ name, status: "PASS" });
+      console.log(`PASS  ${name}`);
+    } catch (e) {
+      results.push({ name, status: "FAIL", error: e.message });
+      console.log(`FAIL  ${name}`);
+      console.log(`      ${e.message}`);
+    }
+  };
+
+  await transport.start();
+
+  await check("initialize", async () => {
+    const r = await transport.request("initialize", {
+      protocolVersion: "2025-06-18",
+      capabilities: {},
+      clientInfo: { name: "olostep-smoke", version: "1" },
+    });
+    if (!r?.serverInfo?.name) throw new Error("no serverInfo in response");
+  });
+
+  await transport.notify("notifications/initialized", {});
+
+  let tools;
+  await check("tools/list returns 10 tools", async () => {
+    const r = await transport.request("tools/list", {});
+    tools = r?.tools || [];
+    if (tools.length !== 10) {
+      throw new Error(`got ${tools.length} tools, expected 10`);
+    }
+  });
+
+  await check("schema: wait_for_completion_seconds.maximum = 900", () => {
+    const t = tools.find((x) => x.name === "batch_scrape_urls");
+    const w = t?.inputSchema?.properties?.wait_for_completion_seconds;
+    if (w?.maximum !== 900) throw new Error(`maximum = ${w?.maximum}, expected 900`);
+  });
+
+  await check("schema: create_crawl description marked PREFERRED for crawling", () => {
+    const t = tools.find((x) => x.name === "create_crawl");
+    if (!t?.description?.includes("PREFERRED tool for crawling")) {
+      throw new Error("description missing 'PREFERRED tool for crawling'");
+    }
+  });
+
+  await check("schema: batch_scrape_urls description steers away from crawling", () => {
+    const t = tools.find((x) => x.name === "batch_scrape_urls");
+    if (!t?.description?.includes("Do NOT use this for crawling")) {
+      throw new Error("description missing 'Do NOT use this for crawling'");
+    }
+  });
+
+  await check("schema: create_map description prefers create_crawl for whole-site", () => {
+    const t = tools.find((x) => x.name === "create_map");
+    if (!t?.description?.includes("Prefer `create_crawl`")) {
+      throw new Error("description missing 'Prefer `create_crawl`'");
+    }
+  });
+
+  if (skipReal) {
+    console.log("SKIP  scrape_website real call (no OLOSTEP_TEST_API_KEY or --no-real)");
+  } else {
+    await check("scrape_website https://example.com returns 'Example Domain'", async () => {
+      const r = await transport.request("tools/call", {
+        name: "scrape_website",
+        arguments: { url_to_scrape: "https://example.com", output_format: "markdown" },
+      });
+      const text = r?.content?.[0]?.text || "";
+      if (!text.includes("Example Domain")) {
+        throw new Error(`response did not contain 'Example Domain'. First 200 chars: ${text.slice(0, 200)}`);
+      }
+    });
+  }
+
+  await transport.stop();
+
+  const passed = results.filter((r) => r.status === "PASS").length;
+  const failed = results.filter((r) => r.status === "FAIL").length;
+  console.log(`\n${passed} passed, ${failed} failed${skipReal ? " (real-API check skipped)" : ""}`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+main().catch((e) => {
+  console.error("fatal:", e.message);
+  process.exit(1);
+});


### PR DESCRIPTION
Adds CI guarantees that the MCP server keeps working for users — on every PR, and **most importantly a full real-API gate on every merge** so bad code can never reach clients.

## The testing pyramid

| Stage | When | What runs | Real API? | Blocks what |
|---|---|---|---|---|
| Contract check | every PR (incl. forks) | stdio schema invariants + description goldens | No | PR merge |
| Integration test | every PR (internal branches) | stdio, real `scrape_website` | Yes | PR merge |
| **E2E gate** | **merge → main** | **full 15-scenario suite vs locally-spawned server** | **Yes** | **the deploy itself** |
| Production canary | after ECS rollout | quick check vs live `mcp.olostep.com` | Yes | nothing (alert only) |

### The E2E gate is the headline

When a PR merges, `deploy-aws.yml` now runs as **two jobs**:

1. **`e2e-gate`** — builds the code, spawns the server locally in HTTP mode, and runs the full e2e suite against it: every one of the 10 tools, the async batch + crawl polling workflows end-to-end, structured-JSON answers, country routing, and error handling.
2. **`deploy`** — `needs: e2e-gate`. Builds the Docker image, pushes to ECR, deploys to ECS, runs the production canary.

**If the e2e gate fails, the deploy job never starts.** No image is built, no push, no ECS update. Clients keep the last known-good version. Bad code is physically blocked from reaching them.

## Files

- `tests/smoke.mjs` — fast PR-level runner (stdio + remote). Contract + integration checks.
- `tests/check-descriptions.mjs` + `tests/description-goldens.json` — exact-wording goldens for tool descriptions.
- `tests/e2e.mjs` — the deep 15-scenario suite, using the official MCP SDK client. Target configurable via `MCP_URL` so it runs against localhost in CI and the hosted URL anywhere else. Verified locally: 17 pass / 1 skip / 0 fail.
- `.github/workflows/pr-test.yml` — contract check (everyone) + integration test (non-fork PRs). Concurrency-cancels stale runs. Comment warns against `pull_request_target`.
- `.github/workflows/verify-pr.yml` — maintainer-triggered integration verify for fork PRs, gated by the `prod-smoke` environment (secret only released after reviewer approval) + `npm ci --ignore-scripts`.
- `.github/workflows/deploy-aws.yml` — split into `e2e-gate` + `deploy`. `deploy` blocked unless the gate is green.

## Cost / time tradeoff

The e2e gate makes ~20–30 real Olostep API calls per merge (batch + crawl included) and takes ~5–10 min. That is the price of "no bad code reaches clients." Merges to main aren't frequent, so it's acceptable. Targets are free/predictable (`example.com`, `docs.olostep.com`).

## One manual step before fully live

Create the `prod-smoke` GitHub Environment (Settings → Environments → New → `prod-smoke` → Required reviewers → add yourself). Until then, `verify-pr.yml` runs without the reviewer gate. I couldn't create it via API — needs repo-admin token scope.

## Notes for the reviewer

- The `e2e-gate` job only runs on merge to `main`, so it gets its first real exercise on the first merge after this PR. The suite itself was verified locally against a locally-spawned HTTP server (same invocation the workflow uses).
- `scripts/e2e-hosted-mcp.mjs` (a previously-untracked deep suite) was relocated to `tests/e2e.mjs` and parameterized — it's the same suite, now committed and CI-wired.
- Architect-review fixes already folded in: goldens instead of brittle substring asserts, env-gated secret on `verify-pr.yml`, concurrency cancellation, SSE parser fix, accurate job naming.

## Policy choices for your review

1. Fork PRs: contract check auto; integration is opt-in via the reviewer-gated manual workflow.
2. E2E gate failure blocks the deploy (good). Post-deploy canary failure is alert-only (no auto-rollback).
3. ~20-30 API credits per merge for the e2e gate — acceptable for the stability guarantee.