### PR TITLE
advertise oauth discovery so chatgpt can link accounts

### DIFF
--- a/deploy/task-definition.json
+++ b/deploy/task-definition.json
@@ -15,7 +15,10 @@
       ],
       "environment": [
         { "name": "TRANSPORT", "value": "http" },
-        { "name": "PORT",      "value": "3000" }
+        { "name": "PORT",      "value": "3000" },
+        { "name": "MCP_OAUTH_AUTHORIZATION_SERVER_URL", "value": "https://cognito-idp.us-east-1.amazonaws.com/us-east-1_GHo5vqMsL" },
+        { "name": "MCP_OAUTH_RESOURCE_URL",             "value": "https://mcp.olostep.com" },
+        { "name": "MCP_OAUTH_SCOPES",                   "value": "olostep/api" }
       ],
       "logConfiguration": {
         "logDriver": "awslogs",

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,28 @@ import { createMap } from "./tools/createMap.js";
 
 dotenv.config();
 
+// --- OAuth resource-server support (additive; dormant unless configured) ---
+// When MCP_OAUTH_AUTHORIZATION_SERVER_URL is set, this server advertises OAuth
+// protected-resource metadata and challenges unauthenticated /mcp requests, so
+// clients like ChatGPT can run the OAuth login flow. The bearer token — whether
+// it's an Olostep API key OR a Cognito OAuth JWT — is forwarded verbatim to
+// api.olostep.com unchanged, so no per-token-type handling is needed here.
+const OAUTH_AS_URL = (process.env.MCP_OAUTH_AUTHORIZATION_SERVER_URL ?? "").replace(/\/+$/, "");
+const OAUTH_SCOPES = (process.env.MCP_OAUTH_SCOPES ?? "olostep/api").split(/\s+/).filter(Boolean);
+const OAUTH_RESOURCE_URL = (process.env.MCP_OAUTH_RESOURCE_URL ?? "").replace(/\/+$/, "");
+const OAUTH_ENABLED = OAUTH_AS_URL.length > 0;
+
+function oauthResourceUrl(req: Request): string {
+    if (OAUTH_RESOURCE_URL) return OAUTH_RESOURCE_URL;
+    const proto = ((req.headers["x-forwarded-proto"] as string) || req.protocol).split(",")[0];
+    const host = ((req.headers["x-forwarded-host"] as string) || req.headers.host || "").split(",")[0];
+    return `${proto}://${host}`;
+}
+
+function oauthProtectedResourceMetadataUrl(req: Request): string {
+    return `${oauthResourceUrl(req)}/.well-known/oauth-protected-resource`;
+}
+
 type ToolResult = { isError?: boolean; content: { type: "text"; text: string }[] };
 
 function wrap(result: { isError?: boolean; content: { type: string; text: string }[] }): ToolResult {
@@ -79,14 +101,35 @@ async function startHttp() {
         res.json({ status: "ok" });
     });
 
+    // OAuth 2.0 Protected Resource Metadata (RFC 9728). Lets ChatGPT discover
+    // which authorization server (Cognito) to use. Only mounted when configured.
+    if (OAUTH_ENABLED) {
+        app.get("/.well-known/oauth-protected-resource", (req: Request, res: Response) => {
+            res.json({
+                resource: oauthResourceUrl(req),
+                authorization_servers: [OAUTH_AS_URL],
+                scopes_supported: OAUTH_SCOPES,
+                resource_documentation: "https://docs.olostep.com/",
+            });
+        });
+    }
+
     app.post("/mcp", async (req: Request, res: Response) => {
         const start = Date.now();
         const auth = req.headers.authorization;
         const apiKey = auth?.startsWith("Bearer ") ? auth.slice(7) : null;
 
         if (!apiKey) {
-            log("warn", "Rejected request — missing API key", { status: 401 });
-            res.status(401).json({ error: "Missing Authorization: Bearer <OLOSTEP_API_KEY>" });
+            // When OAuth is enabled, return the challenge that tells ChatGPT where
+            // to authenticate. API-key clients always send a token so never see this.
+            if (OAUTH_ENABLED) {
+                res.setHeader(
+                    "WWW-Authenticate",
+                    `Bearer resource_metadata="${oauthProtectedResourceMetadataUrl(req)}", scope="${OAUTH_SCOPES.join(" ")}"`
+                );
+            }
+            log("warn", "Rejected request — missing token", { status: 401 });
+            res.status(401).json({ error: "Missing Authorization: Bearer <token>" });
             return;
         }
 


### PR DESCRIPTION
Lets ChatGPT (and any OAuth MCP client) link an Olostep account and act on behalf of that user, without changing anything for existing API-key clients.

## Why
`mcp.olostep.com` already takes the Olostep credential in the `Authorization: Bearer` header and forwards it **verbatim** to `api.olostep.com`. Since the API now accepts both API keys and Cognito OAuth JWTs, an OAuth access token already flows through unchanged — the only missing piece was telling clients *how* to obtain a token. This adds that OAuth discovery.

## What changed
- Serves `/.well-known/oauth-protected-resource` (RFC 9728) pointing at the Cognito issuer + `olostep/api` scope.
- Adds a `WWW-Authenticate: Bearer resource_metadata=..., scope="olostep/api"` challenge to the existing missing-token 401.
- Wires the three `MCP_OAUTH_*` env vars into `deploy/task-definition.json`.
- Token forwarding is **unchanged** — a JWT and an API key are handled identically.

## Safety: additive and env-gated
- All OAuth behavior is gated on `MCP_OAUTH_AUTHORIZATION_SERVER_URL`. Unset → byte-identical to today (no `.well-known` route, plain 401).
- Existing API-key clients (Cursor, etc.) always send a token, so they never hit the challenge. No behavior change for them.

## Verified locally
- OAuth enabled → `/.well-known/oauth-protected-resource` returns correct metadata; `/mcp` without a token → 401 **+** `WWW-Authenticate` challenge.
- OAuth unset → `.well-known` 404 (not mounted); `/mcp` without a token → 401 with **no** challenge (unchanged).

## Depends on
- `api-olostep` accepting Cognito JWTs (PR #95 there) deployed, and its `ALLOWED_OAUTH_CLIENT_IDS` set, before the end-to-end ChatGPT flow bills the user's own team.

## After merge
Deploys via the existing `deploy-aws.yml` pipeline (the new task-def env turns OAuth discovery on). Then point a ChatGPT connector at `https://mcp.olostep.com/mcp` with the Cognito OAuth client.