### PR TITLE
accept url/urls param so chatgpt tool calls dont fail

### DIFF
--- a/src/tools/batchScrapeUrls.ts
+++ b/src/tools/batchScrapeUrls.ts
@@ -17,6 +17,17 @@ export const batchScrapeUrls = {
     "Use this only when you already have an explicit list of URLs to scrape (e.g., user provides a CSV of URLs, or you need to scrape unrelated pages). " +
     "Returns a batch_id immediately. Use `get_batch_results` with the batch_id to fetch the scraped content once the batch completes (~5–8 min). Set `wait_for_completion_seconds` to poll automatically.",
 	schema: {
+		urls: z
+			.array(
+				z.union([
+					z.string().url(),
+					z.object({ url: z.string().url(), custom_id: z.string().optional() }),
+				]),
+			)
+			.min(1)
+			.max(10000)
+			.optional()
+			.describe('Array of URLs to scrape — plain URL strings, or objects with "url" and optional "custom_id".'),
 		urls_to_scrape: z
 			.array(
 				z.object({
@@ -26,7 +37,8 @@ export const batchScrapeUrls = {
 			)
 			.min(1)
 			.max(10000)
-			.describe('JSON array of objects with "url" and optional "custom_id".'),
+			.optional()
+			.describe('Alias for `urls`.'),
 		output_format: z
 			.enum(["markdown", "html", "json", "text"])
 			.default("markdown")
@@ -55,6 +67,7 @@ export const batchScrapeUrls = {
 	},
 	handler: async (
 		{
+			urls,
 			urls_to_scrape,
 			output_format,
 			country,
@@ -62,7 +75,8 @@ export const batchScrapeUrls = {
 			parser,
 			wait_for_completion_seconds,
 		}: {
-			urls_to_scrape: BatchScrapeRequestUrl[];
+			urls?: (string | BatchScrapeRequestUrl)[];
+			urls_to_scrape?: BatchScrapeRequestUrl[];
 			output_format: "markdown" | "html" | "json" | "text";
 			country?: string;
 			wait_before_scraping?: number;
@@ -72,6 +86,10 @@ export const batchScrapeUrls = {
 		apiKey: string,
 		orbitKey?: string,
 	) => {
+		const rawUrls = urls ?? urls_to_scrape;
+		if (!rawUrls || rawUrls.length === 0) {
+			return { isError: true, content: [{ type: "text", text: "Error: 'urls' is required (a non-empty array of URLs)." }] };
+		}
 		try {
 			const headers = new Headers({
 				"Content-Type": "application/json",
@@ -79,10 +97,11 @@ export const batchScrapeUrls = {
 			});
 
 			const formats: string[] = [output_format];
-			const items = urls_to_scrape.map((item) => ({
-				url: item.url,
-				...(item.custom_id && { custom_id: item.custom_id }),
-			}));
+			const items = rawUrls.map((item) =>
+				typeof item === "string"
+					? { url: item }
+					: { url: item.url, ...(item.custom_id && { custom_id: item.custom_id }) },
+			);
 
 			const payload: Record<string, unknown> = {
 				items,

--- a/src/tools/createCrawl.ts
+++ b/src/tools/createCrawl.ts
@@ -25,7 +25,8 @@ export const createCrawl = {
     "Starts an ASYNC crawl that autonomously discovers and scrapes pages by following links from a start URL. Returns a crawl_id - the crawl runs in the background. You MUST then call `get_crawl_results` with the returned crawl_id to poll status and retrieve the scraped pages. " +
     "Do NOT call `get_batch_results` with a crawl_id - crawls and batches are separate resources.",
 	schema: {
-		start_url: z.string().url().describe("Starting URL for the crawl."),
+		url: z.string().url().optional().describe("Starting URL for the crawl."),
+		start_url: z.string().url().optional().describe("Alias for `url`."),
 		max_pages: z.number().int().min(1).default(10).describe("Maximum number of pages to crawl."),
 		follow_links: z.boolean().default(true).describe("Whether to follow links found on pages."),
 		output_format: z
@@ -37,6 +38,7 @@ export const createCrawl = {
 	},
 	handler: async (
 		{
+			url,
 			start_url,
 			max_pages,
 			follow_links,
@@ -44,7 +46,8 @@ export const createCrawl = {
 			country,
 			parser,
 		}: {
-			start_url: string;
+			url?: string;
+			start_url?: string;
 			max_pages?: number;
 			follow_links?: boolean;
 			output_format: "markdown" | "html" | "json" | "text";
@@ -54,6 +57,10 @@ export const createCrawl = {
 		apiKey: string,
 		orbitKey?: string,
 	) => {
+		const targetUrl = url ?? start_url;
+		if (!targetUrl) {
+			return { isError: true, content: [{ type: "text", text: "Error: a 'url' is required." }] };
+		}
 		try {
 			const headers = new Headers({
 				"Content-Type": "application/json",
@@ -62,7 +69,7 @@ export const createCrawl = {
 
 			const formats: string[] = [output_format];
 			const payload: Record<string, unknown> = {
-				start_url,
+				start_url: targetUrl,
 				max_pages: max_pages ?? 10,
 				follow_links: follow_links ?? true,
 				formats,

--- a/src/tools/createMap.ts
+++ b/src/tools/createMap.ts
@@ -23,7 +23,8 @@ export const createMap = {
     "Use when the user wants a list of links: 'show me all URLs on this site', 'map this website', or when you want to surface candidate URLs to the user before scraping a subset. " +
     "Prefer `create_crawl` if the goal is to scrape the whole site — it discovers AND scrapes in one workflow. Use this only when the URL list itself is the deliverable.",
 	schema: {
-		website_url: z.string().url().describe("Website URL to extract links from."),
+		url: z.string().url().optional().describe("Website URL to extract links from."),
+		website_url: z.string().url().optional().describe("Alias for `url`."),
 		search_query: z.string().optional().describe('Optional search query to filter URLs (e.g., "blog").'),
 		top_n: z.number().int().min(1).optional().describe("Optional limit for number of URLs returned."),
 		include_url_patterns: z
@@ -37,13 +38,15 @@ export const createMap = {
 	},
 	handler: async (
 		{
+			url,
 			website_url,
 			search_query,
 			top_n,
 			include_url_patterns,
 			exclude_url_patterns,
 		}: {
-			website_url: string;
+			url?: string;
+			website_url?: string;
 			search_query?: string;
 			top_n?: number;
 			include_url_patterns?: string[];
@@ -51,6 +54,10 @@ export const createMap = {
 		},
 		apiKey: string,
 	) => {
+		const targetUrl = url ?? website_url;
+		if (!targetUrl) {
+			return { isError: true, content: [{ type: "text", text: "Error: a 'url' is required." }] };
+		}
 		try {
 			const headers = new Headers({
 				"Content-Type": "application/json",
@@ -58,7 +65,7 @@ export const createMap = {
 			});
 
 			const payload: Record<string, unknown> = {
-				url: website_url,
+				url: targetUrl,
 			};
 			if (search_query) payload.search_query = search_query;
 			if (typeof top_n === "number") payload.top_n = top_n;

--- a/src/tools/getWebpageMarkdown.ts
+++ b/src/tools/getWebpageMarkdown.ts
@@ -14,11 +14,16 @@ export const getWebpageMarkdown = {
     name: "get_webpage_content",
     description: "Retrieve content of a webpage in markdown",
     schema: {
-        url_to_scrape: z.string().url().describe("The URL of the webpage to scrape."),
+        url: z.string().url().optional().describe("The URL of the webpage to scrape."),
+        url_to_scrape: z.string().url().optional().describe("Alias for `url`."),
         wait_before_scraping: z.number().int().min(0).default(0).describe("Time to wait in milliseconds before starting the scrape."),
         country: z.string().optional().describe("Residential country to load the request from (e.g., US, CA, GB). Optional."),
     },
-    handler: async ({ url_to_scrape, wait_before_scraping, country }: { url_to_scrape: string; wait_before_scraping: number; country?: string }, apiKey: string, orbitKey?: string) => {
+    handler: async ({ url, url_to_scrape, wait_before_scraping, country }: { url?: string; url_to_scrape?: string; wait_before_scraping: number; country?: string }, apiKey: string, orbitKey?: string) => {
+        const targetUrl = url ?? url_to_scrape;
+        if (!targetUrl) {
+            return { isError: true, content: [{ type: "text", text: "Error: a 'url' is required." }] };
+        }
         try {
             const headers = new Headers({
                 'Content-Type': 'application/json',
@@ -26,7 +31,7 @@ export const getWebpageMarkdown = {
             });
 
             const payload = {
-                url_to_scrape: url_to_scrape,
+                url_to_scrape: targetUrl,
                 wait_before_scraping: wait_before_scraping,
                 formats: ["markdown"],
                 ...(country && { country: country }),

--- a/src/tools/scrapeWebsite.ts
+++ b/src/tools/scrapeWebsite.ts
@@ -24,7 +24,8 @@ export const scrapeWebsite = {
 	description:
 		"Extract content from a single URL. Supports multiple formats and JavaScript rendering.",
 	schema: {
-		url_to_scrape: z.string().url().describe("The URL of the website you want to scrape."),
+		url: z.string().url().optional().describe("The URL of the website you want to scrape."),
+		url_to_scrape: z.string().url().optional().describe("Alias for `url`."),
 		output_format: z
 			.enum(["markdown", "html", "json", "text"])
 			.default("markdown")
@@ -47,13 +48,15 @@ export const scrapeWebsite = {
 	},
 	handler: async (
 		{
+			url,
 			url_to_scrape,
 			output_format,
 			country,
 			wait_before_scraping,
 			parser,
 		}: {
-			url_to_scrape: string;
+			url?: string;
+			url_to_scrape?: string;
 			output_format: "markdown" | "html" | "json" | "text";
 			country?: string;
 			wait_before_scraping?: number;
@@ -62,6 +65,10 @@ export const scrapeWebsite = {
 		apiKey: string,
 		orbitKey?: string,
 	) => {
+		const targetUrl = url ?? url_to_scrape;
+		if (!targetUrl) {
+			return { isError: true, content: [{ type: "text", text: "Error: a 'url' is required." }] };
+		}
 		try {
 			const headers = new Headers({
 				"Content-Type": "application/json",
@@ -70,7 +77,7 @@ export const scrapeWebsite = {
 
 			const formats: string[] = [output_format];
 			const body: Record<string, unknown> = {
-				url_to_scrape,
+				url_to_scrape: targetUrl,
 				formats,
 				wait_before_scraping: wait_before_scraping ?? 0,
 			};


### PR DESCRIPTION
ChatGPT's model calls the scrape/crawl/map tools with `url` (and `urls`), but the schemas required `url_to_scrape` / `website_url` / `start_url` / `urls_to_scrape` with `additionalProperties: false` — so ChatGPT's natural argument got hard-rejected ("Additional properties are not allowed ('url' was unexpected)").

## Fix
For each URL-taking tool, accept the natural name as the primary param and keep the old name as an optional alias; the handler normalizes (`url ?? url_to_scrape`). Backward-compatible — existing clients (Cursor, the Olostep MCP skill) that send the old names keep working.

| Tool | Now accepts | Old name (still works) |
|---|---|---|
| `get_webpage_content` | `url` | `url_to_scrape` |
| `scrape_website` | `url` | `url_to_scrape` |
| `create_map` | `url` | `website_url` |
| `create_crawl` | `url` | `start_url` |
| `batch_scrape_urls` | `urls` (strings or {url,custom_id}) | `urls_to_scrape` |

## Verified
- `npm run build` clean.
- Each tool's exposed schema now lists `url`/`urls` first, old name as alias.
- Handlers throw a clear "a 'url' is required" message if neither is provided.