### PR TITLE
drop follow_links from create_crawl (no-op param)

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,7 +407,6 @@ Start an **async** crawl that autonomously discovers and scrapes entire websites
   "arguments": {
     "start_url": "https://example.com/docs",
     "max_pages": 25,
-    "follow_links": true,
     "output_format": "markdown",
     "country": "US",
     "parser": "@olostep/doc-parser"
@@ -417,7 +416,7 @@ Start an **async** crawl that autonomously discovers and scrapes entire websites
 
 #### Response includes:
 
-- `crawl_id`, `object`, `status`, `start_url`, `max_pages`, `follow_links`, `created`, `formats`, `country`, `parser`
+- `crawl_id`, `object`, `status`, `start_url`, `max_pages`, `created`, `formats`, `country`, `parser`
 
 > Pair this call with `get_crawl_results` — do **not** pass a `crawl_id` to `get_batch_results` (crawls and batches are separate resources).
 

--- a/docker-mcp-registry/tools.json
+++ b/docker-mcp-registry/tools.json
@@ -144,13 +144,7 @@
       {
         "name": "max_pages",
         "type": "number",
-        "desc": "Maximum number of pages to crawl",
-        "optional": true
-      },
-      {
-        "name": "follow_links",
-        "type": "boolean",
-        "desc": "Whether to follow links found on pages",
+        "desc": "Maximum number of pages to crawl. Set to 1 to scrape only the start URL",
         "optional": true
       },
       {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "olostep-mcp",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "description": "API to search, extract and structure web data. Features web scraping, AI-powered answers with citations, batch processing (10k URLs), and autonomous site crawling for AI agents and LLMs.",
   "type": "module",
   "mcpName": "io.github.olostep/olostep-mcp-server",

--- a/server.json
+++ b/server.json
@@ -3,13 +3,13 @@
   "name": "io.github.olostep/olostep-mcp-server",
   "title": "Olostep MCP Server",
   "description": "Search, scrape, and crawl the web for AI agents. Batch scraping and answers with citations.",
-  "version": "1.0.13",
+  "version": "1.0.15",
   "icon": "assets/logo.png",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "olostep-mcp",
-      "version": "1.0.13",
+      "version": "1.0.15",
       "transport": {
         "type": "stdio"
       }

--- a/src/tools/createCrawl.ts
+++ b/src/tools/createCrawl.ts
@@ -10,7 +10,6 @@ export interface OlostepCrawlResponse {
 	status?: string;
 	start_url?: string;
 	max_pages?: number;
-	follow_links?: boolean;
 	created?: string;
 	formats?: string[];
 	country?: string;
@@ -27,8 +26,7 @@ export const createCrawl = {
 	schema: {
 		url: z.string().url().optional().describe("Starting URL for the crawl."),
 		start_url: z.string().url().optional().describe("Alias for `url`."),
-		max_pages: z.number().int().min(1).default(10).describe("Maximum number of pages to crawl."),
-		follow_links: z.boolean().default(true).describe("Whether to follow links found on pages."),
+		max_pages: z.number().int().min(1).default(10).describe("Maximum number of pages to crawl. Set to 1 to scrape only the start URL."),
 		output_format: z
 			.enum(["markdown", "html", "json", "text"])
 			.default("markdown")
@@ -41,7 +39,6 @@ export const createCrawl = {
 			url,
 			start_url,
 			max_pages,
-			follow_links,
 			output_format,
 			country,
 			parser,
@@ -49,7 +46,6 @@ export const createCrawl = {
 			url?: string;
 			start_url?: string;
 			max_pages?: number;
-			follow_links?: boolean;
 			output_format: "markdown" | "html" | "json" | "text";
 			country?: string;
 			parser?: string;
@@ -71,7 +67,6 @@ export const createCrawl = {
 			const payload: Record<string, unknown> = {
 				start_url: targetUrl,
 				max_pages: max_pages ?? 10,
-				follow_links: follow_links ?? true,
 				formats,
 			};
 			if (country) payload.country = country;

--- a/tests/e2e.mjs
+++ b/tests/e2e.mjs
@@ -278,7 +278,6 @@ async function main() {
     const r = await call(client, "create_crawl", {
       start_url: "https://example.com",
       max_pages: 2,
-      follow_links: true,
       output_format: "markdown",
     }, 120000);
     const data = parseToolText(r);


### PR DESCRIPTION
## What

Removes the `follow_links` parameter from the `create_crawl` MCP tool — schema, handler, payload, response interface, registry schema (`docker-mcp-registry/tools.json`), README, and e2e test. Bumps to `1.0.15`.

## Why

`follow_links` was advertised as a real crawl parameter (default `true`) and forwarded to the API, but the crawl backend (`crawls/src/crawl-executions/crawl-main.js`) never reads it — so it was a **silent no-op**. Users (and ChatGPT/agent tool calls) could pass `follow_links: false` expecting to scope the crawl to one page and be silently overcharged for up to `max_pages`.

It was never a real API param — also just removed from the public docs (olostep/docs#88). This was the last place it lived in code.

For single-page crawls, the real lever is **`max_pages: 1`** (now noted in the param description).

## Verified
- `tsc` build passes clean.
- Zero `follow_links` references remain in src, build, registry, README, or tests.