### PR TITLE
THREADS-44: Use the real amazon-it-product parser name in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,7 +301,7 @@ Extract content from a single URL. Supports multiple formats and JavaScript rend
     "output_format": "markdown",
     "country": "US",
     "wait_before_scraping": 1000,
-    "parser": "@olostep/amazon-product"
+    "parser": "@olostep/amazon-it-product"
   }
 }
 ```
@@ -388,7 +388,7 @@ Scrape up to 10k URLs at the same time. Perfect for large-scale data extraction.
     "output_format": "markdown",
     "country": "US",
     "wait_before_scraping": 500,
-    "parser": "@olostep/amazon-product"
+    "parser": "@olostep/amazon-it-product"
   }
 }
 ```

--- a/docker-mcp-registry/tools.json
+++ b/docker-mcp-registry/tools.json
@@ -29,7 +29,7 @@
       {
         "name": "parser",
         "type": "string",
-        "desc": "Optional parser ID for specialized extraction (e.g., @olostep/amazon-product)",
+        "desc": "Optional parser ID for specialized extraction (e.g., @olostep/amazon-it-product)",
         "optional": true
       }
     ]

--- a/src/tools/scrapeWebsite.ts
+++ b/src/tools/scrapeWebsite.ts
@@ -44,7 +44,7 @@ export const scrapeWebsite = {
 		parser: z
 			.string()
 			.optional()
-			.describe('Optional parser ID for specialized extraction (e.g., "@olostep/amazon-product").'),
+			.describe('Optional parser ID for specialized extraction (e.g., "@olostep/amazon-it-product").'),
 	},
 	handler: async (
 		{


### PR DESCRIPTION
The scrape examples referenced `@olostep/amazon-product`, which does not exist. Replaced it with the real `@olostep/amazon-it-product` in the tool source, the registry schema, and the README. Same root cause as OLO-SCRAPE-04.