### PR TITLE
THREADS-26/27: send include_urls and exclude_urls to the maps API

### DIFF
--- a/src/tools/createMap.ts
+++ b/src/tools/createMap.ts
@@ -69,8 +69,9 @@ export const createMap = {
 			};
 			if (search_query) payload.search_query = search_query;
 			if (typeof top_n === "number") payload.top_n = top_n;
-			if (include_url_patterns?.length) payload.include_url_patterns = include_url_patterns;
-			if (exclude_url_patterns?.length) payload.exclude_url_patterns = exclude_url_patterns;
+			// REST /v1/maps filters on include_urls / exclude_urls, so map the tool input names to those keys.
+			if (include_url_patterns?.length) payload.include_urls = include_url_patterns;
+			if (exclude_url_patterns?.length) payload.exclude_urls = exclude_url_patterns;
 
 			const response = await fetch(OLOSTEP_MAP_API_URL, {
 				method: "POST",


### PR DESCRIPTION
The create_map tool sent include_url_patterns / exclude_url_patterns to /v1/maps, but the REST API filters on include_urls / exclude_urls, so the glob filter was silently ignored.

Now the tool maps its inputs to the correct payload keys (include_urls / exclude_urls). The tool-facing input names are unchanged, so existing MCP users are unaffected, but the filter now actually applies. Verified live that include_urls narrows the result set. OLO-MAP-03 / OLO-MAP-04.