### PR TITLE
feat: add monitors product tools

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "olostep-mcp",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "olostep-mcp",
-      "version": "1.0.14",
+      "version": "1.0.15",
       "license": "ISC",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,14 @@ import { getBatchResults } from "./tools/getBatchResults.js";
 import { createCrawl } from "./tools/createCrawl.js";
 import { getCrawlResults } from "./tools/getCrawlResults.js";
 import { createMap } from "./tools/createMap.js";
+import { createMonitor } from "./tools/createMonitor.js";
+import { listMonitors } from "./tools/listMonitors.js";
+import { getMonitor } from "./tools/getMonitor.js";
+import { updateMonitor } from "./tools/updateMonitor.js";
+import { pauseMonitor } from "./tools/pauseMonitor.js";
+import { resumeMonitor } from "./tools/resumeMonitor.js";
+import { deleteMonitor } from "./tools/deleteMonitor.js";
+import { getMonitorEvents } from "./tools/getMonitorEvents.js";
 
 dotenv.config();
 
@@ -66,6 +74,8 @@ const tools: AnyTool[] = [
     createMap, createCrawl, getCrawlResults, batchScrapeUrls, getBatchResults,
     answers, searchWeb, scrapeWebsite, getWebpageMarkdown,
     getWebsiteMap,
+    createMonitor, listMonitors, getMonitor, updateMonitor,
+    pauseMonitor, resumeMonitor, deleteMonitor, getMonitorEvents,
 ];
 
 function createMcpServer(apiKey: string, orbitKey?: string) {

--- a/src/tools/createMonitor.ts
+++ b/src/tools/createMonitor.ts
@@ -1,0 +1,152 @@
+import { z } from "zod";
+import fetch, { Headers } from "node-fetch";
+
+const MONITORS_URL = "https://api.olostep.com/v1/monitors";
+
+export const createMonitor = {
+	name: "create_monitor",
+	description:
+		"Create a recurring web monitor. Olostep visits the target on a schedule, detects changes, and can notify you by email, Slack, or SMS, or POST a webhook. Returns status 'provisioning' immediately; the monitor becomes 'active' once setup completes (usually within a minute).",
+	schema: {
+		query: z
+			.string()
+			.min(1)
+			.describe(
+				"What to watch for — written as a natural-language question or instruction. Example: \"Has the pricing on this page changed?\" or \"Track the in-stock status of the main product.\"",
+			),
+		source_policy: z
+			.object({
+				include_urls: z
+					.array(z.string().url())
+					.optional()
+					.describe("URLs to monitor. If omitted, Olostep infers them from the query."),
+				exclude_urls: z.array(z.string().url()).optional().describe("URLs to skip."),
+				include_domains: z.array(z.string()).optional().describe("Restrict monitoring to these domains."),
+				exclude_domains: z.array(z.string()).optional().describe("Never visit these domains."),
+			})
+			.optional()
+			.describe("Controls which URLs are fetched on each run."),
+		frequency: z
+			.string()
+			.max(50)
+			.optional()
+			.describe(
+				'How often to run. Natural language: "every hour", "every day at 9am", "every 30 minutes" (minimum 10 minutes). Defaults to "every hour".',
+			),
+		notification: z
+			.object({
+				events: z
+					.array(z.enum(["changed", "first_snapshot"]))
+					.optional()
+					.describe(
+						'Which events trigger notifications. Defaults to ["changed","first_snapshot"] when channels are set.',
+					),
+				channels: z
+					.array(
+						z.object({
+							type: z.enum(["email", "slack", "sms"]).describe("Delivery channel type."),
+							target: z
+								.string()
+								.describe(
+									"Destination: an email address, a Slack webhook URL, or an E.164 phone number (+1…).",
+								),
+							events: z
+								.array(z.enum(["changed", "first_snapshot"]))
+								.optional()
+								.describe("Per-channel event filter; overrides the top-level events list."),
+						}),
+					)
+					.optional()
+					.describe("Where to send notifications."),
+			})
+			.optional()
+			.describe("Notification settings. Omit to receive no notifications."),
+		webhook: z
+			.object({
+				url: z.string().url().describe("HTTPS endpoint that receives a POST on each monitor run."),
+			})
+			.optional()
+			.describe("Webhook called on each run. Note: payloads are not signed."),
+		output_schema: z
+			.record(z.unknown())
+			.optional()
+			.describe(
+				"Optional JSON Schema for structured data extraction from the monitored page. Example: {\"type\":\"object\",\"properties\":{\"price\":{\"type\":\"number\"}}}",
+			),
+		metadata: z
+			.record(z.string())
+			.optional()
+			.describe("Key/value labels you can use to tag this monitor (up to 50 keys, 500 chars each)."),
+	},
+	handler: async (
+		params: {
+			query: string;
+			source_policy?: {
+				include_urls?: string[];
+				exclude_urls?: string[];
+				include_domains?: string[];
+				exclude_domains?: string[];
+			};
+			frequency?: string;
+			notification?: {
+				events?: ("changed" | "first_snapshot")[];
+				channels?: {
+					type: "email" | "slack" | "sms";
+					target: string;
+					events?: ("changed" | "first_snapshot")[];
+				}[];
+			};
+			webhook?: { url: string };
+			output_schema?: Record<string, unknown>;
+			metadata?: Record<string, string>;
+		},
+		apiKey: string,
+	) => {
+		try {
+			const body: Record<string, unknown> = { query: params.query };
+			if (params.source_policy) body.source_policy = params.source_policy;
+			if (params.frequency) body.frequency = params.frequency;
+			if (params.notification) body.notification = params.notification;
+			if (params.webhook) body.webhook = params.webhook;
+			if (params.output_schema) body.output_schema = params.output_schema;
+			if (params.metadata) body.metadata = params.metadata;
+
+			const response = await fetch(MONITORS_URL, {
+				method: "POST",
+				headers: new Headers({
+					"Content-Type": "application/json",
+					Authorization: `Bearer ${apiKey}`,
+				}),
+				body: JSON.stringify(body),
+			});
+
+			const data = await response.json();
+
+			if (!response.ok) {
+				return {
+					isError: true,
+					content: [
+						{
+							type: "text",
+							text: `Olostep API Error ${response.status}: ${JSON.stringify(data)}`,
+						},
+					],
+				};
+			}
+
+			return {
+				content: [{ type: "text", text: JSON.stringify(data, null, 2) }],
+			};
+		} catch (error: unknown) {
+			return {
+				isError: true,
+				content: [
+					{
+						type: "text",
+						text: `Error: Failed to create monitor. ${error instanceof Error ? error.message : String(error)}`,
+					},
+				],
+			};
+		}
+	},
+};

--- a/src/tools/deleteMonitor.ts
+++ b/src/tools/deleteMonitor.ts
@@ -1,0 +1,52 @@
+import { z } from "zod";
+import fetch, { Headers } from "node-fetch";
+
+const MONITORS_BASE_URL = "https://api.olostep.com/v1/monitors";
+
+export const deleteMonitor = {
+	name: "delete_monitor",
+	description:
+		"Delete a monitor. The monitor's schedule is cancelled and it is soft-deleted (status becomes 'deleted'). This cannot be undone. Snapshot history is preserved but the monitor stops running.",
+	schema: {
+		monitor_id: z
+			.string()
+			.startsWith("monitor_")
+			.describe('The monitor ID to delete (starts with "monitor_").'),
+	},
+	handler: async (params: { monitor_id: string }, apiKey: string) => {
+		try {
+			const response = await fetch(`${MONITORS_BASE_URL}/${params.monitor_id}`, {
+				method: "DELETE",
+				headers: new Headers({ Authorization: `Bearer ${apiKey}` }),
+			});
+
+			const data = await response.json();
+
+			if (!response.ok) {
+				return {
+					isError: true,
+					content: [
+						{
+							type: "text",
+							text: `Olostep API Error ${response.status}: ${JSON.stringify(data)}`,
+						},
+					],
+				};
+			}
+
+			return {
+				content: [{ type: "text", text: JSON.stringify(data, null, 2) }],
+			};
+		} catch (error: unknown) {
+			return {
+				isError: true,
+				content: [
+					{
+						type: "text",
+						text: `Error: Failed to delete monitor. ${error instanceof Error ? error.message : String(error)}`,
+					},
+				],
+			};
+		}
+	},
+};

--- a/src/tools/getMonitor.ts
+++ b/src/tools/getMonitor.ts
@@ -1,0 +1,64 @@
+import { z } from "zod";
+import fetch, { Headers } from "node-fetch";
+
+const MONITORS_BASE_URL = "https://api.olostep.com/v1/monitors";
+
+export const getMonitor = {
+	name: "get_monitor",
+	description:
+		"Retrieve a single monitor by ID, including its schedule, current status, last-run result, and total snapshot count.",
+	schema: {
+		monitor_id: z
+			.string()
+			.startsWith("monitor_")
+			.describe('The monitor ID returned by create_monitor (starts with "monitor_").'),
+		include_total_count: z
+			.boolean()
+			.optional()
+			.describe("Set to false to skip the snapshot count query and reduce latency. Default: true."),
+	},
+	handler: async (
+		params: { monitor_id: string; include_total_count?: boolean },
+		apiKey: string,
+	) => {
+		try {
+			const url = new URL(`${MONITORS_BASE_URL}/${params.monitor_id}`);
+			if (params.include_total_count === false) {
+				url.searchParams.set("include_total_count", "false");
+			}
+
+			const response = await fetch(url.toString(), {
+				method: "GET",
+				headers: new Headers({ Authorization: `Bearer ${apiKey}` }),
+			});
+
+			const data = await response.json();
+
+			if (!response.ok) {
+				return {
+					isError: true,
+					content: [
+						{
+							type: "text",
+							text: `Olostep API Error ${response.status}: ${JSON.stringify(data)}`,
+						},
+					],
+				};
+			}
+
+			return {
+				content: [{ type: "text", text: JSON.stringify(data, null, 2) }],
+			};
+		} catch (error: unknown) {
+			return {
+				isError: true,
+				content: [
+					{
+						type: "text",
+						text: `Error: Failed to get monitor. ${error instanceof Error ? error.message : String(error)}`,
+					},
+				],
+			};
+		}
+	},
+};

--- a/src/tools/getMonitorEvents.ts
+++ b/src/tools/getMonitorEvents.ts
@@ -1,0 +1,80 @@
+import { z } from "zod";
+import fetch, { Headers } from "node-fetch";
+
+const MONITORS_BASE_URL = "https://api.olostep.com/v1/monitors";
+
+export const getMonitorEvents = {
+	name: "get_monitor_events",
+	description:
+		"List the snapshot history for a monitor, newest first. Each event shows whether a change was detected and a plain-language summary of what changed. Use the next_cursor for pagination.",
+	schema: {
+		monitor_id: z
+			.string()
+			.startsWith("monitor_")
+			.describe('The monitor ID to fetch events for (starts with "monitor_").'),
+		limit: z
+			.number()
+			.int()
+			.min(1)
+			.max(100)
+			.optional()
+			.describe("Number of events to return (1–100). Default: 25."),
+		cursor: z
+			.string()
+			.optional()
+			.describe("Pagination cursor from a previous response's next_cursor field."),
+		status: z
+			.enum(["all", "changed", "unchanged"])
+			.optional()
+			.describe('Filter events by change status. Default: "all".'),
+	},
+	handler: async (
+		params: {
+			monitor_id: string;
+			limit?: number;
+			cursor?: string;
+			status?: "all" | "changed" | "unchanged";
+		},
+		apiKey: string,
+	) => {
+		try {
+			const url = new URL(`${MONITORS_BASE_URL}/${params.monitor_id}/events`);
+			if (params.limit) url.searchParams.set("limit", String(params.limit));
+			if (params.cursor) url.searchParams.set("cursor", params.cursor);
+			if (params.status && params.status !== "all") url.searchParams.set("status", params.status);
+
+			const response = await fetch(url.toString(), {
+				method: "GET",
+				headers: new Headers({ Authorization: `Bearer ${apiKey}` }),
+			});
+
+			const data = await response.json();
+
+			if (!response.ok) {
+				return {
+					isError: true,
+					content: [
+						{
+							type: "text",
+							text: `Olostep API Error ${response.status}: ${JSON.stringify(data)}`,
+						},
+					],
+				};
+			}
+
+			return {
+				content: [{ type: "text", text: JSON.stringify(data, null, 2) }],
+			};
+		} catch (error: unknown) {
+			return {
+				isError: true,
+				content: [
+					{
+						type: "text",
+						text: `Error: Failed to get monitor events. ${error instanceof Error ? error.message : String(error)}`,
+					},
+				],
+			};
+		}
+	},
+};

--- a/src/tools/listMonitors.ts
+++ b/src/tools/listMonitors.ts
@@ -1,0 +1,57 @@
+import { z } from "zod";
+import fetch, { Headers } from "node-fetch";
+
+const MONITORS_URL = "https://api.olostep.com/v1/monitors";
+
+export const listMonitors = {
+	name: "list_monitors",
+	description: "List all monitors for this API key. Returns each monitor's id, query, schedule, status, and last-run summary.",
+	schema: {
+		include_deleted: z
+			.boolean()
+			.optional()
+			.describe("Set to true to include soft-deleted monitors in the response. Default: false."),
+	},
+	handler: async (
+		params: { include_deleted?: boolean },
+		apiKey: string,
+	) => {
+		try {
+			const url = new URL(MONITORS_URL);
+			if (params.include_deleted) url.searchParams.set("include_deleted", "true");
+
+			const response = await fetch(url.toString(), {
+				method: "GET",
+				headers: new Headers({ Authorization: `Bearer ${apiKey}` }),
+			});
+
+			const data = await response.json();
+
+			if (!response.ok) {
+				return {
+					isError: true,
+					content: [
+						{
+							type: "text",
+							text: `Olostep API Error ${response.status}: ${JSON.stringify(data)}`,
+						},
+					],
+				};
+			}
+
+			return {
+				content: [{ type: "text", text: JSON.stringify(data, null, 2) }],
+			};
+		} catch (error: unknown) {
+			return {
+				isError: true,
+				content: [
+					{
+						type: "text",
+						text: `Error: Failed to list monitors. ${error instanceof Error ? error.message : String(error)}`,
+					},
+				],
+			};
+		}
+	},
+};

--- a/src/tools/pauseMonitor.ts
+++ b/src/tools/pauseMonitor.ts
@@ -1,0 +1,52 @@
+import { z } from "zod";
+import fetch, { Headers } from "node-fetch";
+
+const MONITORS_BASE_URL = "https://api.olostep.com/v1/monitors";
+
+export const pauseMonitor = {
+	name: "pause_monitor",
+	description:
+		"Pause an active monitor. The schedule stops running; existing snapshots and history are preserved. Only monitors with status 'active' can be paused. Resume with resume_monitor.",
+	schema: {
+		monitor_id: z
+			.string()
+			.startsWith("monitor_")
+			.describe('The monitor ID to pause (starts with "monitor_").'),
+	},
+	handler: async (params: { monitor_id: string }, apiKey: string) => {
+		try {
+			const response = await fetch(`${MONITORS_BASE_URL}/${params.monitor_id}/pause`, {
+				method: "POST",
+				headers: new Headers({ Authorization: `Bearer ${apiKey}` }),
+			});
+
+			const data = await response.json();
+
+			if (!response.ok) {
+				return {
+					isError: true,
+					content: [
+						{
+							type: "text",
+							text: `Olostep API Error ${response.status}: ${JSON.stringify(data)}`,
+						},
+					],
+				};
+			}
+
+			return {
+				content: [{ type: "text", text: JSON.stringify(data, null, 2) }],
+			};
+		} catch (error: unknown) {
+			return {
+				isError: true,
+				content: [
+					{
+						type: "text",
+						text: `Error: Failed to pause monitor. ${error instanceof Error ? error.message : String(error)}`,
+					},
+				],
+			};
+		}
+	},
+};

--- a/src/tools/resumeMonitor.ts
+++ b/src/tools/resumeMonitor.ts
@@ -1,0 +1,52 @@
+import { z } from "zod";
+import fetch, { Headers } from "node-fetch";
+
+const MONITORS_BASE_URL = "https://api.olostep.com/v1/monitors";
+
+export const resumeMonitor = {
+	name: "resume_monitor",
+	description:
+		"Resume a paused monitor. The schedule is re-enabled and the monitor starts running again. Only monitors with status 'paused' can be resumed.",
+	schema: {
+		monitor_id: z
+			.string()
+			.startsWith("monitor_")
+			.describe('The monitor ID to resume (starts with "monitor_").'),
+	},
+	handler: async (params: { monitor_id: string }, apiKey: string) => {
+		try {
+			const response = await fetch(`${MONITORS_BASE_URL}/${params.monitor_id}/resume`, {
+				method: "POST",
+				headers: new Headers({ Authorization: `Bearer ${apiKey}` }),
+			});
+
+			const data = await response.json();
+
+			if (!response.ok) {
+				return {
+					isError: true,
+					content: [
+						{
+							type: "text",
+							text: `Olostep API Error ${response.status}: ${JSON.stringify(data)}`,
+						},
+					],
+				};
+			}
+
+			return {
+				content: [{ type: "text", text: JSON.stringify(data, null, 2) }],
+			};
+		} catch (error: unknown) {
+			return {
+				isError: true,
+				content: [
+					{
+						type: "text",
+						text: `Error: Failed to resume monitor. ${error instanceof Error ? error.message : String(error)}`,
+					},
+				],
+			};
+		}
+	},
+};

--- a/src/tools/updateMonitor.ts
+++ b/src/tools/updateMonitor.ts
@@ -1,0 +1,128 @@
+import { z } from "zod";
+import fetch, { Headers } from "node-fetch";
+
+const MONITORS_BASE_URL = "https://api.olostep.com/v1/monitors";
+
+export const updateMonitor = {
+	name: "update_monitor",
+	description:
+		"Update a monitor's frequency, notification settings, webhook, or metadata. Include only the fields you want to change. Changing frequency deletes and recreates the underlying schedule. Passing webhook: null removes the webhook. Unsupported fields are silently ignored.",
+	schema: {
+		monitor_id: z
+			.string()
+			.startsWith("monitor_")
+			.describe('The monitor ID to update (starts with "monitor_").'),
+		frequency: z
+			.string()
+			.max(50)
+			.optional()
+			.describe(
+				'New schedule frequency in natural language, e.g. "every 6 hours" or "every day at noon". Minimum: every 10 minutes.',
+			),
+		notification: z
+			.object({
+				events: z
+					.array(z.enum(["changed", "first_snapshot"]))
+					.optional()
+					.describe("Which events trigger notifications."),
+				channels: z
+					.array(
+						z.object({
+							type: z.enum(["email", "slack", "sms"]),
+							target: z.string(),
+							events: z.array(z.enum(["changed", "first_snapshot"])).optional(),
+						}),
+					)
+					.optional()
+					.describe("Where to send notifications."),
+			})
+			.nullable()
+			.optional()
+			.describe("Replace notification settings entirely. Pass null or empty to clear."),
+		webhook: z
+			.object({ url: z.string().url() })
+			.nullable()
+			.optional()
+			.describe("Replace the webhook URL. Pass null to remove the webhook."),
+		metadata: z
+			.record(z.string())
+			.optional()
+			.describe(
+				'Key/value labels. Merged with existing metadata (Stripe-style: pass "" as a value to delete that key).',
+			),
+	},
+	handler: async (
+		params: {
+			monitor_id: string;
+			frequency?: string;
+			notification?: {
+				events?: ("changed" | "first_snapshot")[];
+				channels?: {
+					type: "email" | "slack" | "sms";
+					target: string;
+					events?: ("changed" | "first_snapshot")[];
+				}[];
+			} | null;
+			webhook?: { url: string } | null;
+			metadata?: Record<string, string>;
+		},
+		apiKey: string,
+	) => {
+		try {
+			const body: Record<string, unknown> = {};
+			if (params.frequency !== undefined) body.frequency = params.frequency;
+			if (params.notification !== undefined) body.notification = params.notification;
+			if (params.webhook !== undefined) body.webhook = params.webhook;
+			if (params.metadata !== undefined) body.metadata = params.metadata;
+
+			if (Object.keys(body).length === 0) {
+				return {
+					isError: true,
+					content: [
+						{
+							type: "text",
+							text: "Error: No fields provided to update. Pass at least one of: frequency, notification, webhook, metadata.",
+						},
+					],
+				};
+			}
+
+			const response = await fetch(`${MONITORS_BASE_URL}/${params.monitor_id}`, {
+				method: "POST",
+				headers: new Headers({
+					"Content-Type": "application/json",
+					Authorization: `Bearer ${apiKey}`,
+				}),
+				body: JSON.stringify(body),
+			});
+
+			const data = await response.json();
+
+			if (!response.ok) {
+				return {
+					isError: true,
+					content: [
+						{
+							type: "text",
+							text: `Olostep API Error ${response.status}: ${JSON.stringify(data)}`,
+						},
+					],
+				};
+			}
+
+			return {
+				content: [{ type: "text", text: JSON.stringify(data, null, 2) }],
+			};
+		} catch (error: unknown) {
+			return {
+				isError: true,
+				content: [
+					{
+						type: "text",
+						text: `Error: Failed to update monitor. ${error instanceof Error ? error.message : String(error)}`,
+					},
+				],
+			};
+		}
+	},
+};

--- a/tests/description-goldens.json
+++ b/tests/description-goldens.json
@@ -13,11 +13,23 @@
     "create_map": {
       "description": "Get a LIST of URLs on a website (URL discovery only — does NOT scrape content). Use when the user wants a list of links: 'show me all URLs on this site', 'map this website', or when you want to surface candidate URLs to the user before scraping a subset. Prefer `create_crawl` if the goal is to scrape the whole site — it discovers AND scrapes in one workflow. Use this only when the URL list itself is the deliverable."
     },
+    "create_monitor": {
+      "description": "Create a recurring web monitor. Olostep visits the target on a schedule, detects changes, and can notify you by email, Slack, or SMS, or POST a webhook. Returns status 'provisioning' immediately; the monitor becomes 'active' once setup completes (usually within a minute)."
+    },
+    "delete_monitor": {
+      "description": "Delete a monitor. The monitor's schedule is cancelled and it is soft-deleted (status becomes 'deleted'). This cannot be undone. Snapshot history is preserved but the monitor stops running."
+    },
     "get_batch_results": {
       "description": "Retrieve the status and scraped content for a batch job. Pass the batch_id returned by batch_scrape_urls. If the batch is completed, returns the scraped content for each URL. If still in_progress, returns the current status so you can call again later."
     },
     "get_crawl_results": {
       "description": "Retrieve the status and scraped pages for a crawl job. Pass the crawl_id returned by create_crawl. If the crawl is still in_progress, returns the current status so you can call again later (poll every ~10 seconds). Once completed, returns the list of discovered pages with their scraped content in the requested formats. This is the REQUIRED companion to create_crawl — create_crawl only kicks off the async job, this tool is how you actually get the content."
+    },
+    "get_monitor": {
+      "description": "Retrieve a single monitor by ID, including its schedule, current status, last-run result, and total snapshot count."
+    },
+    "get_monitor_events": {
+      "description": "List the snapshot history for a monitor, newest first. Each event shows whether a change was detected and a plain-language summary of what changed. Use the next_cursor for pagination."
     },
     "get_webpage_content": {
       "description": "Retrieve content of a webpage in markdown"
@@ -25,11 +37,23 @@
     "get_website_urls": {
       "description": "Search and retrieve relevant URLs from a website (URL discovery only - does NOT scrape content). Use this only when the user wants a *filtered list of links* matching a search query. **Do NOT use this as a precursor to scraping** - if the user wants to scrape/crawl a site, use `create_crawl` directly."
     },
+    "list_monitors": {
+      "description": "List all monitors for this API key. Returns each monitor's id, query, schedule, status, and last-run summary."
+    },
+    "pause_monitor": {
+      "description": "Pause an active monitor. The schedule stops running; existing snapshots and history are preserved. Only monitors with status 'active' can be paused. Resume with resume_monitor."
+    },
+    "resume_monitor": {
+      "description": "Resume a paused monitor. The schedule is re-enabled and the monitor starts running again. Only monitors with status 'paused' can be resumed."
+    },
     "scrape_website": {
       "description": "Extract content from a single URL. Supports multiple formats and JavaScript rendering."
     },
     "search_web": {
       "description": "Search the web for a given query and return structured results (non-AI, parser-based)."
+    },
+    "update_monitor": {
+      "description": "Update a monitor's frequency, notification settings, webhook, or metadata. Include only the fields you want to change. Changing frequency deletes and recreates the underlying schedule. Passing webhook: null removes the webhook. Unsupported fields are silently ignored."
     }
   }
 }

--- a/tests/smoke.mjs
+++ b/tests/smoke.mjs
@@ -208,11 +208,11 @@ async function main() {
   await transport.notify("notifications/initialized", {});
 
   let tools;
-  await check("tools/list returns 10 tools", async () => {
+  await check("tools/list returns 18 tools", async () => {
     const r = await transport.request("tools/list", {});
     tools = r?.tools || [];
-    if (tools.length !== 10) {
-      throw new Error(`got ${tools.length} tools, expected 10`);
+    if (tools.length !== 18) {
+      throw new Error(`got ${tools.length} tools, expected 18`);
     }
   });
 
@@ -248,6 +248,14 @@ async function main() {
       "get_crawl_results",
       "create_map",
       "get_website_urls",
+      "create_monitor",
+      "list_monitors",
+      "get_monitor",
+      "update_monitor",
+      "pause_monitor",
+      "resume_monitor",
+      "delete_monitor",
+      "get_monitor_events",
     ];
     const got = new Set(tools.map((t) => t.name));
     const missing = expected.filter((n) => !got.has(n));


### PR DESCRIPTION
Adds 8 new MCP tools for the monitors product:

- `createMonitor` — create a new URL monitor
- `listMonitors` — list all monitors with optional pagination
- `getMonitor` — fetch a single monitor by ID
- `updateMonitor` — update monitor settings
- `pauseMonitor` — pause a running monitor
- `resumeMonitor` — resume a paused monitor
- `deleteMonitor` — delete a monitor
- `getMonitorEvents` — list events for a monitor

All tools follow the existing input/output patterns in the repo. Descriptions pass the golden-file check. This is part of the monitors rollout across all developer surfaces (run iss-mqji8aas-t2q4).

Draft until the monitors API reference docs land.