### PR TITLE
scrape_website json extraction schema + answers guidance

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "olostep-mcp",
-  "version": "1.0.15",
+  "version": "1.0.17",
   "description": "API to search, extract and structure web data. Features web scraping, AI-powered answers with citations, batch processing (10k URLs), and autonomous site crawling for AI agents and LLMs.",
   "type": "module",
   "mcpName": "io.github.olostep/olostep-mcp-server",

--- a/server.json
+++ b/server.json
@@ -3,13 +3,13 @@
   "name": "io.github.olostep/olostep-mcp-server",
   "title": "Olostep MCP Server",
   "description": "Search, scrape, and crawl the web for AI agents. Batch scraping and answers with citations.",
-  "version": "1.0.15",
+  "version": "1.0.17",
   "icon": "assets/logo.png",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "olostep-mcp",
-      "version": "1.0.15",
+      "version": "1.0.17",
       "transport": {
         "type": "stdio"
       }

--- a/src/tools/answers.ts
+++ b/src/tools/answers.ts
@@ -19,7 +19,7 @@ export const answers = {
 		"Answer a factual question using web search, optionally shaped into a flat JSON object of fields " +
 		"(returned with sources and citations). Best for a bounded, factual answer (e.g. a company's founding " +
 		"year, a product's current price). It is NOT reliable for enumerating a live list from a page (e.g. " +
-		"'the latest N blog posts with titles and dates') — for that, use create_map or get_webpage_content on " +
+		"'the latest N blog posts with titles and dates'). For that, use create_map or get_webpage_content on " +
 		"the page and read the results instead.",
 	schema: {
 		task: z.string().describe("Question or task to answer using web data."),
@@ -29,7 +29,7 @@ export const answers = {
 			.describe(
 				'Optional shape for the answer: a flat JSON object of the fields you want. ' +
 				'Example: { "book_title": "", "author": "", "release_date": "" }. ' +
-				'Keep it flat — deeply nested shapes or long lists are unreliable.',
+				'Keep it flat. Deeply nested shapes or long lists are unreliable.',
 			),
 	},
 	handler: async (

--- a/src/tools/answers.ts
+++ b/src/tools/answers.ts
@@ -16,14 +16,20 @@ export interface OlostepAnswersResponse {
 export const answers = {
 	name: "answers",
 	description:
-		"Search the web and return AI-powered answers in the JSON structure you want, with sources and citations.",
+		"Answer a factual question using web search, optionally shaped into a flat JSON object of fields " +
+		"(returned with sources and citations). Best for a bounded, factual answer (e.g. a company's founding " +
+		"year, a product's current price). It is NOT reliable for enumerating a live list from a page (e.g. " +
+		"'the latest N blog posts with titles and dates') — for that, use create_map or get_webpage_content on " +
+		"the page and read the results instead.",
 	schema: {
 		task: z.string().describe("Question or task to answer using web data."),
 		json: z
 			.union([z.string(), z.record(z.any())])
 			.optional()
 			.describe(
-				'Optional JSON schema/object or a short description of the desired output shape. Example object: { "book_title": "", "author": "", "release_date": "" }',
+				'Optional shape for the answer: a flat JSON object of the fields you want. ' +
+				'Example: { "book_title": "", "author": "", "release_date": "" }. ' +
+				'Keep it flat — deeply nested shapes or long lists are unreliable.',
 			),
 	},
 	handler: async (

--- a/src/tools/scrapeWebsite.ts
+++ b/src/tools/scrapeWebsite.ts
@@ -29,7 +29,11 @@ export const scrapeWebsite = {
 		output_format: z
 			.enum(["markdown", "html", "json", "text"])
 			.default("markdown")
-			.describe('Choose format ("html", "markdown", "json", or "text"). Default: "markdown"'),
+			.describe(
+				'Output format. "markdown" (default), "html", and "text" need no extra config. ' +
+				'"json" returns STRUCTURED data and requires either a `parser` OR an `llm_extract` schema ' +
+				'describing the fields to pull. Do not request "json" on its own.',
+			),
 		country: z
 			.string()
 			.optional()
@@ -45,6 +49,17 @@ export const scrapeWebsite = {
 			.string()
 			.optional()
 			.describe('Optional parser ID for specialized extraction (e.g., "@olostep/amazon-product").'),
+		llm_extract: z
+			.object({
+				schema: z.record(z.any()).optional(),
+				prompt: z.string().optional(),
+			})
+			.optional()
+			.describe(
+				'Defines what to pull when output_format is "json". Provide a `schema` (a JSON-schema object of ' +
+				'the fields you want, e.g. { "type": "object", "properties": { "title": { "type": "string" } } }) ' +
+				'and/or a `prompt`. Required for JSON output unless a `parser` is given.',
+			),
 	},
 	handler: async (
 		{
@@ -54,6 +69,7 @@ export const scrapeWebsite = {
 			country,
 			wait_before_scraping,
 			parser,
+			llm_extract,
 		}: {
 			url?: string;
 			url_to_scrape?: string;
@@ -61,6 +77,7 @@ export const scrapeWebsite = {
 			country?: string;
 			wait_before_scraping?: number;
 			parser?: string;
+			llm_extract?: { schema?: Record<string, unknown>; prompt?: string };
 		},
 		apiKey: string,
 		orbitKey?: string,
@@ -68,6 +85,17 @@ export const scrapeWebsite = {
 		const targetUrl = url ?? url_to_scrape;
 		if (!targetUrl) {
 			return { isError: true, content: [{ type: "text", text: "Error: a 'url' is required." }] };
+		}
+		if (output_format === "json" && !parser && !llm_extract) {
+			return {
+				isError: true,
+				content: [{
+					type: "text",
+					text: 'Error: output_format "json" needs a `parser` or an `llm_extract` schema ' +
+						'(e.g. llm_extract: { schema: { "type": "object", "properties": { "title": { "type": "string" } } } }). ' +
+						'Add one, or use "markdown"/"html"/"text".',
+				}],
+			};
 		}
 		try {
 			const headers = new Headers({
@@ -86,6 +114,10 @@ export const scrapeWebsite = {
 			if (parser) {
 				// Include parser-based extraction alongside selected format
 				body.parser_extract = { parser_id: parser };
+			}
+			if (llm_extract) {
+				// Schema/prompt the API uses to fill JSON output
+				body.llm_extract = llm_extract;
 			}
 
 			const response = await fetch(OLOSTEP_SCRAPE_API_URL, {

--- a/tests/description-goldens.json
+++ b/tests/description-goldens.json
@@ -2,7 +2,7 @@
   "version": 1,
   "tools": {
     "answers": {
-      "description": "Search the web and return AI-powered answers in the JSON structure you want, with sources and citations."
+      "description": "Answer a factual question using web search, optionally shaped into a flat JSON object of fields (returned with sources and citations). Best for a bounded, factual answer (e.g. a company's founding year, a product's current price). It is NOT reliable for enumerating a live list from a page (e.g. 'the latest N blog posts with titles and dates'). For that, use create_map or get_webpage_content on the page and read the results instead."
     },
     "batch_scrape_urls": {
       "description": "Scrape a SPECIFIC, KNOWN list of URLs (typically from different domains). **Do NOT use this for crawling a website** - if the user wants to scrape a whole site or 'crawl' a domain, use `create_crawl` instead. Use this only when you already have an explicit list of URLs to scrape (e.g., user provides a CSV of URLs, or you need to scrape unrelated pages). Returns a batch_id immediately. Use `get_batch_results` with the batch_id to fetch the scraped content once the batch completes (~5–8 min). Set `wait_for_completion_seconds` to poll automatically."


### PR DESCRIPTION
## What

**scrape_website**
- Add an `llm_extract` param (`{ schema, prompt }`) so `output_format: "json"` returns structured data. It maps to the scrapes API `llm_extract` field.
- Guard: if `json` is requested without a `parser` or `llm_extract`, return a clear message instead of the backend "requires a parser or extraction schema" error.
- Clarify the `output_format` docs so bare `json` is not picked by default.

**answers**
- Scope the description to bounded factual questions with a flat object answer.
- Steer list-style extraction (for example "the latest N posts with titles and dates") to `create_map` / `get_webpage_content`.
- Note in the `json` param that flat shapes are more reliable than nested lists.

## Why
`output_format: "json"` on scrape_website failed with "JSON requires a parser or extraction schema" because the tool never exposed a way to pass one. `answers` returned NOT_FOUND on list-style requests because it is built for factual answers, not enumerating a live list.

## Notes
- get_webpage_content is markdown only, no change needed.
- Builds clean (tsc). No behavior change for existing markdown/html/text usage.