### PR TITLE
Serve OpenAI Apps domain-verification token

### DIFF
--- a/deploy/task-definition.json
+++ b/deploy/task-definition.json
@@ -18,7 +18,8 @@
         { "name": "PORT",      "value": "3000" },
         { "name": "MCP_OAUTH_AUTHORIZATION_SERVER_URL", "value": "https://cognito-idp.us-east-1.amazonaws.com/us-east-1_GHo5vqMsL" },
         { "name": "MCP_OAUTH_RESOURCE_URL",             "value": "https://mcp.olostep.com" },
-        { "name": "MCP_OAUTH_SCOPES",                   "value": "olostep/api" }
+        { "name": "MCP_OAUTH_SCOPES",                   "value": "olostep/api" },
+        { "name": "OPENAI_APPS_CHALLENGE_TOKEN",         "value": "7sOnWbNuPHQCFp1sS161PKyur62vGkdeGLX8qTJ7IOI" }
       ],
       "logConfiguration": {
         "logDriver": "awslogs",

--- a/src/index.ts
+++ b/src/index.ts
@@ -101,6 +101,19 @@ async function startHttp() {
         res.json({ status: "ok" });
     });
 
+    // OpenAI Apps domain verification. Serves the challenge token as plain text
+    // at the origin-root well-known URL so ChatGPT can confirm we control this
+    // host. Token comes from an env var so it can be set/rotated without a code
+    // change. Dormant (404) until the token is configured.
+    app.get("/.well-known/openai-apps-challenge", (_req: Request, res: Response) => {
+        const token = process.env.OPENAI_APPS_CHALLENGE_TOKEN;
+        if (!token) {
+            res.status(404).type("text/plain").send("");
+            return;
+        }
+        res.type("text/plain").send(token);
+    });
+
     // OAuth 2.0 Protected Resource Metadata (RFC 9728). Lets ChatGPT discover
     // which authorization server (Cognito) to use. Only mounted when configured.
     if (OAUTH_ENABLED) {


### PR DESCRIPTION
Adds a route that serves the OpenAI Apps domain-verification token as plain text at `/.well-known/openai-apps-challenge` on `mcp.olostep.com`, so ChatGPT can verify we control the host.

The token is read from the `OPENAI_APPS_CHALLENGE_TOKEN` env var, so it can be set or rotated without a code change. The route is dormant (returns 404) until the env var is set, so merging this is safe and changes nothing until the token is configured on the task.

Verified locally: with the env var set the path returns 200 text/plain with the exact token; without it, 404.

To activate after merge and deploy: set `OPENAI_APPS_CHALLENGE_TOKEN` on the mcp ECS task, then click Verify in the OpenAI app settings.