### PR TITLE
Add tool annotations (readOnlyHint/destructiveHint/openWorldHint)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -68,13 +68,27 @@ const tools: AnyTool[] = [
     getWebsiteMap,
 ];
 
+// MCP tool annotations. Every tool must declare all three hints (some clients,
+// e.g. ChatGPT Apps, reject tools that omit any of them). All Olostep tools hit
+// the live web (open world) and none delete or overwrite data (never
+// destructive). Most only read; the two that start jobs are writes. Default is
+// read-only so any new tool is valid out of the box — list writers explicitly.
+const WRITE_TOOLS = new Set(["create_crawl", "batch_scrape_urls"]);
+function annotationsFor(name: string) {
+    return {
+        readOnlyHint: !WRITE_TOOLS.has(name),
+        destructiveHint: false,
+        openWorldHint: true,
+    };
+}
+
 function createMcpServer(apiKey: string, orbitKey?: string) {
     const server = new McpServer({ name: "olostep", version: "1.0.0" });
 
     for (const tool of tools) {
         server.registerTool(
             tool.name,
-            { description: tool.description, inputSchema: tool.schema },
+            { description: tool.description, inputSchema: tool.schema, annotations: annotationsFor(tool.name) },
             async (params: Record<string, unknown>) => wrap(await tool.handler(params, apiKey, orbitKey))
         );
     }


### PR DESCRIPTION
ChatGPT Apps hard-rejects any MCP tool that does not declare all three of readOnlyHint, destructiveHint, openWorldHint. This adds them to all 10 tools.

Classification (from actual behavior):
- openWorldHint: true for all — every tool reaches the live web.
- destructiveHint: false for all — none delete or overwrite data.
- readOnlyHint: true for the 8 read tools; false for create_crawl and batch_scrape_urls, which start jobs.

Applied centrally with a read-only default and an explicit writer list, so any future tool is valid by default and can't reintroduce this blocker. Verified via a real MCP tools/list call that all 10 tools emit all three hints.