### PR TITLE
Drop experimental execution field from tool listing

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -86,11 +86,16 @@ function createMcpServer(apiKey: string, orbitKey?: string) {
     const server = new McpServer({ name: "olostep", version: "1.0.0" });
 
     for (const tool of tools) {
-        server.registerTool(
+        const registered = server.registerTool(
             tool.name,
             { description: tool.description, inputSchema: tool.schema, annotations: annotationsFor(tool.name) },
             async (params: Record<string, unknown>) => wrap(await tool.handler(params, apiKey, orbitKey))
         );
+        // The SDK stamps every tool with an experimental `execution: {taskSupport}`
+        // field (its async-tasks feature). We don't use tasks, and that extra
+        // field can trip strict tool-list validators, so drop it — keeping the
+        // wire shape to plain name/description/inputSchema/annotations.
+        (registered as { execution?: unknown }).execution = undefined;
     }
 
     return server;


### PR DESCRIPTION
The SDK stamps every tool in tools/list with an experimental `execution: {taskSupport: "forbidden"}` field (its async-tasks feature, which we do not use). That non-standard field is the only thing making our tool objects non-vanilla, and strict tool-list validators (e.g. the ChatGPT Apps submission scanner) can reject a tool whose shape they do not recognize.

This clears the field after registration so each tool serializes as plain name/description/inputSchema/annotations. Annotations are unaffected.

Verified locally: create_map now has keys [name, description, inputSchema, annotations], no execution, annotations intact.